### PR TITLE
Normalize projections

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,10 +1,10 @@
 package:
-  name: nexpy
-  version: "0.2.1"
+  name: nexusformat
+  version: "0.2.2"
 
 source:
   git_url: https://github.com/nexpy/nexusformat.git
-  git_tag: v0.2.1
+  git_tag: v0.2.2
 
 build:
   entry_points:

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -3941,7 +3941,7 @@ class NXdata(NXgroup):
 
     __div__ = __truediv__
 
-    def project(self, axes, limits, averaged=False):
+    def project(self, axes, limits, summed=True):
         """
         Projects the data along a specified 1D axis or 2D axes summing over the
         limits, which are specified as tuples for each dimension.
@@ -3967,10 +3967,10 @@ class NXdata(NXgroup):
                     if projection_axes[i] > slab_axis:
                         projection_axes[i] -= 1
         if projection_axes:
-            if averaged:
-                result = result.average(projection_axes)
-            else:
+            if summed:
                 result = result.sum(projection_axes)
+            else:
+                result = result.average(projection_axes)
         if len(axes) > 1 and axes[0] > axes[1]:
             result[result.nxsignal.nxname] = result.nxsignal.transpose()
             if result.nxerrors:


### PR DESCRIPTION
This adds the ability to average projections, i.e., divide projections by the number of summed pixels, through new keywords to the sum and projection methods, and a new function, 'average'. The default behavior is the same as before.