### PR TITLE
Add rpm spec file

### DIFF
--- a/nexusformat.spec
+++ b/nexusformat.spec
@@ -1,0 +1,41 @@
+%global srcname nexusformat
+
+%define debug_package %{nil}
+
+Name:           python-%{srcname}
+Version:        0.2.2
+Release:        1%{?dist}
+Summary:        Python API to NeXus files using h5py
+
+License:        BSD
+URL:            https://nexpy.github.io/nexpy/
+Source0:        https://github.com/nexpy/nexusformat/archive/v%{version}.zip
+
+Requires:       h5py
+
+
+%{?python_provide:%python_provide python-%{srcname}}
+
+%description
+Python API to NeXus files using h5py
+
+%prep
+%autosetup -n %{srcname}-%{version}
+
+%build
+%py2_build
+
+%install
+%py2_install
+
+
+%files
+%doc README.rst README.md README
+%{python2_sitelib}/nexusformat/*
+%{python2_sitelib}/nexusformat-%{version}-py2*.egg-info/*
+%{_bindir}/nxstack
+%{_bindir}/nxstartserver
+
+%changelog
+* Thu Apr  7 2016 Stuart Campbell <campbellsi@ornl.gov> - 0.2.2-1
+- Initial package

--- a/nexusformat.spec
+++ b/nexusformat.spec
@@ -12,9 +12,13 @@ URL:            https://nexpy.github.io/nexpy/
 Source0:        https://github.com/nexpy/nexusformat/archive/v%{version}.zip
 
 Requires:       h5py
+Requires:	numpy
 
+BuildRequires:  numpy
+BuildRequires:  python2-devel
+BuildRequires:  python-setuptools
 
-%{?python_provide:%python_provide python-%{srcname}}
+BuildArch:      noarch
 
 %description
 Python API to NeXus files using h5py


### PR DESCRIPTION
Initial version of spec file to use to create rpms.  This spec is quite generic, but I have only tested on RedHat based systems (i.e. Fedora/RHEL).