### PR TITLE
Bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ or
     $ easy_install nexusformat
 ```
 
+If you have an Anaconda installation, use::
+
+```
+    $ conda install -c nexpy nexusformat
+```
+
 The source code can be downloaded from the NeXpy Git repository:
 
 ```
@@ -50,16 +56,6 @@ more details of the nature of these dependencies in the
 
 * h5py                 http://www.h5py.org
 * numpy                http://numpy.org
-
-The remote server requires the Pyro4 package.
-
-* pyro4                http://pythonhosted.org//Pyro4/
-
-The following environment variable may need to be set
-
-PYTHONPATH --> paths to numpy if installed in a nonstandard place
-
-All of the above are included in the Enthought Python Distribution v7.3.
 
 User Support
 ============

--- a/README.rst
+++ b/README.rst
@@ -11,6 +11,10 @@ or::
 
     $ easy_install nexusformat 
 
+or::
+
+    $ conda install -c https://conda.anaconda.org/nexpy nexusformat
+
 If you have trouble with the pip or easy_install installations, you can install
 the package from the source code either by downloading one of the 
 `Github releases <https://github.com/nexpy/nexusformat/releases>`_ or by cloning 
@@ -35,7 +39,6 @@ Library            URL
 =================  ===================================================
 h5py               http://www.h5py.org
 numpy              http://numpy.scipy.org/
-pyro4              http://pythonhosted.org//Pyro4/ (for remote server)
 =================  ===================================================
 
 Versioning

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,10 +1,10 @@
 package:
   name: nexusformat
-  version: "0.2.3"
+  version: "0.3.0"
 
 source:
   git_url: https://github.com/nexpy/nexusformat.git
-  git_tag: v0.2.3
+  git_tag: v0.3.0
 
 build:
   entry_points:

--- a/nexusformat.spec
+++ b/nexusformat.spec
@@ -3,7 +3,7 @@
 %define debug_package %{nil}
 
 Name:           python-%{srcname}
-Version:        0.2.2
+Version:        0.3.0
 Release:        1%{?dist}
 Summary:        Python API to NeXus files using h5py
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #-----------------------------------------------------------------------------
-# Copyright (c) 2013-2014, NeXpy Development Team.
+# Copyright (c) 2013-2016, NeXpy Development Team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/setup.py
+++ b/setup.py
@@ -38,8 +38,7 @@ setup (name =  nexusformat.__package_name__, # NeXpy
        packages = find_packages('src'),
        entry_points={
             # create & install scripts in <python>/bin
-            'console_scripts': ['nxstartserver=nexusformat.pyro.start_server:main',
-                                'nxstack=nexusformat.scripts.nxstack:main'],
+            'console_scripts': ['nxstack=nexusformat.scripts.nxstack:main'],
        },
        classifiers= ['Development Status :: 4 - Beta',
                      'Intended Audience :: Developers',

--- a/src/nexusformat/__init__.py
+++ b/src/nexusformat/__init__.py
@@ -15,7 +15,7 @@ __version__ = get_versions()['version']
 del get_versions
 
 __documentation_author__ = u'Ray Osborn'
-__documentation_copyright__ = u'2013-2015, Ray Osborn'
+__documentation_copyright__ = u'2013-2016, Ray Osborn'
 
 __license__ = u'BSD'
 __author_name__ = u'NeXpy Development Team'
@@ -29,10 +29,11 @@ __description__ = u'nexusformat: Python API to access NeXus data'
 __long_description__ = \
 u"""
 This package provides a Python API to open, create, and manipulate `NeXus data 
-<http://www.nexusformat.org/>`_ written in the HDF5 format. It also includes a 
-server to allow files to be opened on a remote server across a network. The 
-'nexusformat' package provides the underlying API for `NeXpy 
-<http://nexpy.github.io/nexpy>`_, which provides a GUI interface. 
+<http://www.nexusformat.org/>`_ written in the HDF5 format. The 'nexusformat' 
+package provides the underlying API for `NeXpy 
+<http://nexpy.github.io/nexpy>`_, which provides a GUI interface. It also 
+contains a command-line script, `nxstack` for merging TIFF or CBF files into a 
+single HDF5 array.
 
 The latest development version is always available from `NeXpy's GitHub
 site <https://github.com/nexpy/nexusformat>`_.

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -2404,6 +2404,34 @@ class NXfield(NXobject):
     def _getsize(self):
         return len(self)
 
+    def _getcompression(self):
+        if self.nxfilemode:
+            return self.nxfile[self.nxpath].compression
+        else:
+            return self._compression
+
+    def _setcompression(self, value):
+        if self.nxfilemode == 'r':
+            raise NeXusError('NeXus file is locked')
+        elif self.nxfilemode == 'rw':
+            raise NeXusError('Cannot change the compression of a field already stored in a file')
+        self._compression = value
+        
+    def _getchunks(self):
+        if self.nxfilemode:
+            return self.nxfile[self.nxpath].chunks
+        else:
+            return self._chunks
+
+    def _setchunks(self, value):
+        if self.nxfilemode == 'r':
+            raise NeXusError('NeXus file is locked')
+        elif self.nxfilemode == 'rw':
+            raise NeXusError('Cannot change the chunk sizes of a field already stored in a file')
+        elif isinstance(value, (tuple, list)) and len(value) != self.ndim:
+            raise NeXusError('Number of chunks does not match the no. of array dimensions')
+        self._chunks = tuple(value)
+
     nxdata = property(_getdata, _setdata, doc="Property: The data values")
     nxaxes = property(_getaxes, doc="Property: The plotting axes")
     nxtitle = property(_title, "Property: Title for group plot")
@@ -2413,6 +2441,8 @@ class NXfield(NXobject):
     shape = property(_getshape, _setshape, doc="Property: Shape of NeXus field")
     ndim = property(_getndim, doc="Property: No. of dimensions of NeXus field")
     size = property(_getsize, doc="Property: Size of NeXus field")
+    compression = property(_getcompression, _setcompression, doc="Property: Compression of NeXus field")
+    chunks = property(_getchunks, _setchunks, doc="Property: Chunk sizes of NeXus field")
 
     @property
     def safe_attrs(self):

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -753,7 +753,8 @@ def _getvalue(value, dtype=None, shape=None):
             raise NeXusError("Cannot assign a shape to a text string")
         if dtype is not None:
             try:
-                return np.asscalar(np.array(value, dtype=dtype)), dtype, ()
+                _dtype = _getdtype(dtype)
+                return np.asscalar(np.array(value, dtype=_dtype)), _dtype, ()
             except Exception:
                 raise NeXusError("The value is incompatible with the requested dtype")
         else:
@@ -799,7 +800,11 @@ def _getdtype(dtype):
         return string_dtype
     else:
         try:
-            return np.dtype(dtype)
+            _dtype = np.dtype(dtype)
+            if _dtype.kind == 'U':
+                return string_dtype
+            else:
+                return _dtype
         except TypeError:
             raise NeXusError("Invalid data type: %s" % dtype)
 

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -667,6 +667,8 @@ class NXFile(object):
         self._file.attrs['file_time'] = datetime.now().isoformat()
         self._file.attrs['HDF5_Version'] = h5.version.hdf5_version
         self._file.attrs['h5py_version'] = h5.version.version
+        from .. import __version__
+        self._file.attrs['nexusformat_version'] = __version__
 
     def update(self, item, path=None):
         if path is not None:

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 #-----------------------------------------------------------------------------
-# Copyright (c) 2013, NeXpy Development Team.
+# Copyright (c) 2013-2016, NeXpy Development Team.
 #
 # Author: Paul Kienzle, Ray Osborn
 #
@@ -2259,6 +2259,8 @@ class NXfield(NXobject):
             s = repr(s)
             if s.startswith('u'):
                 s = s[1:]
+            if len(self.shape) > 0:
+                s = s[1:-1]
             if len(s) > 60:
                 s = s[0:56] + '...' + "'"
         elif '\n' in s or s == "":

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -3779,7 +3779,7 @@ class NXdata(NXgroup):
                     axis_name = "axis%s" % i
                     self[axis_name] = axis
                     axis_names[i] = axis_name
-            self.attrs["axes"] = ":".join(axis_names.values())
+            self.attrs["axes"] = list(axis_names.values())
         if signal is not None:
             if isinstance(signal, NXfield):
                 if signal.nxname == "unknown" or signal.nxname in self:

--- a/src/nexusformat/requires.py
+++ b/src/nexusformat/requires.py
@@ -13,5 +13,4 @@
 pkg_requirements = [
     'numpy>=1.6.0',
     'h5py',
-    'six',
 ]

--- a/src/nexusformat/scripts/nxstack.py
+++ b/src/nexusformat/scripts/nxstack.py
@@ -19,7 +19,7 @@ import subprocess
 import sys
 import time
 import timeit
-from ConfigParser import ConfigParser
+from configparser import ConfigParser
 from datetime import datetime
 
 import numpy as np
@@ -54,7 +54,7 @@ def get_files(directory, prefix, extension, first=None, last=None,
     filenames = sorted(glob.glob(os.path.join(directory, prefix+'*'+extension)),
                        key=natural_sort, reverse=reverse)
     if len(filenames) == 0:
-        print "No filenames matched!"
+        print("No filenames matched!")
         exit(0)
     max_index = get_index(filenames[-1])
     if first:
@@ -89,9 +89,9 @@ def read_image(filename):
                              np.int32).reshape(imsize)
     else:
         try:
-            from nexpy.readers.tifffile import tifffile as TIFF
+            import tifffile as TIFF
         except ImportError:
-            raise NeXusError('Reading TIFF files requires the TIFF reader installed with NeXpy')
+            raise NeXusError("Please install the 'tifffile' module")
         if filename.endswith('.bz2'):
             import bz2
             tiff_file = TIFF.TiffFile(bz2.BZ2File(filename))
@@ -370,7 +370,7 @@ def main():
                                     version=__version__, note=note)
                                  
         toc = timeit.default_timer()
-        print (toc-tic, 'seconds for', output_file)
+        print(toc-tic, 'seconds for', output_file)
 
 
 if __name__ == "__main__":

--- a/src/nexusformat/scripts/nxstack.py
+++ b/src/nexusformat/scripts/nxstack.py
@@ -78,7 +78,7 @@ def read_image(filename):
         try:
             import pycbf
         except ImportError:
-            raise NeXusError('Reading CBF files requires the pycbf module')
+            raise NeXusError("Please install the 'pycbf' module")
         cbf = pycbf.cbf_handle_struct()
         cbf.read_file(filename, pycbf.MSG_DIGEST)
         cbf.select_datablock(0)


### PR DESCRIPTION
This fixes some inconsistencies in handling large NXfields. When a field is initialized without  setting the data, e.g., because it is too large, any assigned slabs are stored in a core memory file. When the field is saved to a file, the dataset in the core memory file is copied to the new file using h5py. However, if the core memory file had been created without initializing compression, chunk sizes, or fill values, these could not be applied. Now, it is possible to set these as properties up until a slab is initialized, at which time these storage parameters become fixed. Attempts to change them trigger an error. The logical consistency of initializing NXfields has also been approved, and a couple of Python 3 compatibility issues were fixed.