### PR TITLE
Fix printing

### DIFF
--- a/conda-recipe/build.sh
+++ b/conda-recipe/build.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-$PYTHON setup.py install
+$PYTHON setup.py install --single-version-externally-managed


### PR DESCRIPTION
This improves the handling of fixed-length strings in Python 3 by ensuring that they are stored as byte strings, preventing dtype conflicts in Numpy arrays. It also corrects the `__str__` functions by making sure they return encoded strings in Python 2. This stops UnicodeEncodingError when the string contains non-ASCII characters. 