### PR TITLE
Conda installation

### DIFF
--- a/conda-recipe/build.sh
+++ b/conda-recipe/build.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-$PYTHON setup.py install --single-version-externally-managed
+$PYTHON setup.py install --single-version-externally-managed --record installed_files.txt

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,10 +1,10 @@
 package:
   name: nexusformat
-  version: "0.3.1"
+  version: "0.3.2"
 
 source:
   git_url: https://github.com/nexpy/nexusformat.git
-  git_tag: v0.3.1
+  git_tag: v0.3.2
 
 build:
   entry_points:

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -4281,7 +4281,7 @@ class NXdata(NXgroup):
         for axis in axes:
             if axis.nxname not in self:
                 self.insert(axis)
-        axes_attr = ":".join([axis.nxname for axis in axes])
+        axes_attr = [axis.nxname for axis in axes]
         if 'signal' in self.attrs:
             self.attrs['axes'] = axes_attr
 


### PR DESCRIPTION
This adds a `--record` switch to `build.sh` in the conda recipe required by the `single-file-externally-managed` switch. It also fixes a minor inconsistency. The nxaxes property setter does not create a list attribute, which is the default behavior when creating an NXdata group.