### PR TITLE
Fix incompatibility with NeXpy v0.8.1

### DIFF
--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -2953,7 +2953,7 @@ class NXgroup(NXobject):
                 self._name = self.nxclass[2:]
             try: # If one exists, set the class to a valid NXgroup subclass
                 self.__class__ = _getclass(self._class)
-            except KeyError:
+            except Exception:
                 pass
         for item in items:
             try:


### PR DESCRIPTION
Assigning the NXgroup class triggers an error when starting up v0.8.1.
Broadening the exception handling fixes this.