### PR TITLE
Fix mode changes and links in external files

### DIFF
--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -3619,6 +3619,19 @@ class NXlink(NXobject):
             return self
 
     @property
+    def nxfilename(self):
+        if self._filename is not None:
+            if os.path.isabs(self._filename):
+                return self._filename
+            else:
+                return os.path.abspath(os.path.join(
+                    os.path.dirname(self.nxroot.nxfilename), self._filename))
+        elif self._group is not None:
+            return self._group.nxfilename
+        else:
+            return None
+
+    @property
     def nxfilemode(self):
         if self._filename is not None:
             return 'r'

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -396,6 +396,12 @@ class NXFile(object):
         if self._file.id:
             self._file.close()
 
+    def isopen(self):
+        if self._file.id:
+            return True
+        else:
+            return False
+
     def readfile(self):
         """
         Reads the NeXus file structure from the file and returns a tree of 
@@ -746,8 +752,12 @@ class NXFile(object):
     def mode(self, mode):
         if mode == 'rw' or mode == 'r+':
             self._mode = 'rw'
+            if self._file.id and self._file.mode == 'r':
+                self.close()
         else:
             self._mode = 'r'   
+            if self._file.id and self._file.mode == 'r+':
+                self.close()
 
     @property
     def attrs(self):

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -3271,15 +3271,20 @@ class NXgroup(NXobject):
         """
         Adds an attribute to the group.
 
-        If it is not a valid NeXus object (NXfield or NXgroup), the attribute
-        is converted to an NXfield.
+        If it is not a valid NeXus object, the attribute is converted to an 
+        NXfield. If the object is an internal link within an externally linked
+        file, the linked object in the external file is copied.
         """
         if isinstance(value, NXobject):
             if name == 'unknown': 
                 name = value.nxname
             if name in self.entries:
                 raise NeXusError("'%s' already exists in group" % name)
-            self[name] = value
+            if (isinstance(value, NXlink) and 
+                value.nxfilename != self.nxfilename):
+                self[name] = value.nxlink
+            else:
+                self[name] = value
         else:
             if name in self.entries:
                 raise NeXusError("'%s' already exists in group" % name)
@@ -3535,7 +3540,8 @@ class NXlink(NXobject):
         self._entries = {}
         if isinstance(target, NXobject):
             if file is not None:
-                raise NeXusError("For external links, specify the target as a path")
+                raise NeXusError(
+                    "Use the NXgroup makelink function for external links")
             elif isinstance(target, NXlink):
                 raise NeXusError("Cannot link to another NXlink object")
             if name is None:


### PR DESCRIPTION
This ensures that the underlying HDF5 file is closed and reopened when the file mode changes. It also fixes the handling of internal links within externally linked files. 