### PR TITLE
Preserve relative file paths

### DIFF
--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -652,11 +652,11 @@ class NXFile(object):
 
     def _writeexternal(self, item):
         self.nxpath = self.nxpath + '/' + item.nxname
-        if item._abspath and os.path.isabs(item._filename):
-            filename = item._filename
-        else:
+        if os.path.isabs(item._filename) and not item._abspath:
             filename = os.path.relpath(os.path.realpath(item._filename), 
                            os.path.dirname(os.path.realpath(self.filename)))
+        else:
+            filename = item._filename
         self[self.nxpath] = h5.ExternalLink(filename, item._target)
         self.nxpath = self.nxparent
 


### PR DESCRIPTION
If the NeXus tree has already been saved, the input file path of an
external link is preserved. Before, there was an attempt to calculate
the file path relative to the parent file, but this causes problems if
the link is created from another directory.