### PR TITLE
Renaming external links

### DIFF
--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -1278,11 +1278,11 @@ class NXobject(object):
         return self._str_tree(attrs=False, recursive=True)
 
     def rename(self, name):
-        if self.nxfilemode == 'r':
-            raise NeXusError('NeXus file opened as readonly')
-        if self.nxgroup is not None:
+        if self.nxgroup is not None and self.nxgroup.nxfilemode != 'r':
             signal = self.nxgroup.nxsignal
             axes = self.nxgroup.nxaxes
+        elif self.nxfilemode == 'r':
+            raise NeXusError('NeXus file opened as readonly')
         path = self.nxpath
         self.nxname = name
         if self.nxgroup is not None:
@@ -1291,7 +1291,7 @@ class NXobject(object):
             elif axes is not None:
                 if [x for x in axes if x is self]:
                     self.nxgroup.nxaxes = axes
-        if self.nxfilemode == 'rw':
+        if self.nxgroup is not None and self.nxgroup.nxfilemode == 'rw':
             with self.nxfile as f:
                 f.rename(path, self.nxpath)
 

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -3621,7 +3621,7 @@ class NXlink(NXobject):
         if (filename is not None and os.path.exists(filename) and mode == 'rw'):
             with NXFile(filename) as f:
                 f.update(self)
-        if os.path.exists(self.nxfilename):
+        if self._filename and os.path.exists(self.nxfilename):
             with NXFile(self.nxfilename) as f:
                 if self._target in f:
                     item = f.readpath(self._target)


### PR DESCRIPTION
This allows the renaming of external links, which was prevented before because the link itself was marked as read-only. However, it is the parent group that is altered by this, so its read/write status is now checked instead.