### PR TITLE
Add NXRemoteFile class

### DIFF
--- a/src/nexusformat/nexus/__init__.py
+++ b/src/nexusformat/nexus/__init__.py
@@ -68,3 +68,8 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 from .tree import *
+try:
+    import h5pyd
+    from .remote import *
+except ImportError:
+    pass

--- a/src/nexusformat/nexus/remote.py
+++ b/src/nexusformat/nexus/remote.py
@@ -178,7 +178,7 @@ class NXRemoteFile(NXFile):
         return value, shape, dtype, attrs
 
 
-def loadremote(filename, endpoint='http://34.193.81.207:5000', mode='r'):
+def loadremote(filename, endpoint=NX_SERVER, mode='r'):
     """
     Reads a remote NeXus file returning a tree of objects.
     """

--- a/src/nexusformat/nexus/remote.py
+++ b/src/nexusformat/nexus/remote.py
@@ -17,6 +17,8 @@ import h5pyd as h5
 from nexusformat.nexus import *
 
 NX_SERVER = 'hdfgroup.org:5000'
+NX_DOMAIN = 'exfac'
+
 __all__ = ['NXRemoteFile', 'nxloadremote']
 
 class NXRemoteFile(NXFile):
@@ -49,7 +51,8 @@ class NXRemoteFile(NXFile):
     The :class:`NXdata` objects in the returned tree hold the object values.
     """
 
-    def __init__(self, name, mode='r', server=NX_SERVER,  **kwds):
+    def __init__(self, name, mode='r', server=NX_SERVER,  domain=NX_DOMAIN, 
+                 **kwds):
         """
         Creates an h5py File object for reading and writing.
         """
@@ -57,6 +60,7 @@ class NXRemoteFile(NXFile):
         self.name = name
         self._mode = 'r'
         self._server = server
+        self._domain = domain
         self._file = self.h5.File(self.domain, mode, endpoint=server)
         self._filename = self.domain                             
         self._path = '/'
@@ -86,7 +90,7 @@ class NXRemoteFile(NXFile):
     def domain(self):
         domain = self.name.split('.')[0].split('/')
         domain.reverse()
-        domain.append('exfac')
+        domain.append(self._domain)
         return '.'.join(domain)
 
     @property

--- a/src/nexusformat/nexus/remote.py
+++ b/src/nexusformat/nexus/remote.py
@@ -16,10 +16,12 @@ import h5pyd as h5
 
 from nexusformat.nexus import *
 
-NX_SERVER = 'hdfgroup.org:5000'
-NX_DOMAIN = 'exfac'
+NX_SERVER = 'http://hdfgroup.org:5000'
+NX_DOMAIN = 'exfac.org'
 
-__all__ = ['NXRemoteFile', 'nxloadremote']
+__all__ = ['NXRemoteFile', 'nxloadremote', 
+           'nxgetserver', 'nxsetserver', 'NX_SERVER', 
+           'nxgetdomain', 'nxsetdomain', 'NX_DOMAIN']
 
 class NXRemoteFile(NXFile):
 
@@ -51,7 +53,7 @@ class NXRemoteFile(NXFile):
     The :class:`NXdata` objects in the returned tree hold the object values.
     """
 
-    def __init__(self, name, mode='r', server=NX_SERVER,  domain=NX_DOMAIN, 
+    def __init__(self, name, mode='r', server=None,  domain=None, 
                  **kwds):
         """
         Creates an h5py File object for reading and writing.
@@ -59,7 +61,11 @@ class NXRemoteFile(NXFile):
         self.h5 = h5
         self.name = name
         self._mode = 'r'
+        if server is None:
+            server = NX_SERVER
         self._server = server
+        if domain is None:
+            domain = NX_DOMAIN
         self._domain = domain
         self._file = self.h5.File(self.domain, mode, endpoint=server)
         self._filename = self.domain                             
@@ -181,11 +187,42 @@ class NXRemoteFile(NXFile):
         attrs = self.attrs
         return value, shape, dtype, attrs
 
+def getserver():
+    global NX_SERVER
+    return NX_SERVER
 
-def loadremote(filename, endpoint=NX_SERVER, mode='r'):
+nxgetserver = getserver
+
+def setserver(value):
+    """
+    Sets the default server and port for remote access.
+    """
+    global NX_SERVER
+    NX_SERVER = value
+
+nxsetserver = setserver
+
+def getdomain():
+    global NX_DOMAIN
+    return NX_DOMAIN
+
+nxgetdomain = getdomain
+
+def setdomain(value):
+    """
+    Sets the default domain for remote access.
+    """
+    global NX_DOMAIN
+    NX_DOMAIN = value
+
+nxsetdomain = setdomain
+
+def loadremote(filename, endpoint=None, mode='r'):
     """
     Reads a remote NeXus file returning a tree of objects.
     """
+    if endpoint is None:
+        endpoint = NX_SERVER
     with NXRemoteFile(filename, mode, endpoint) as f:
         tree = f.readfile()
     return tree

--- a/src/nexusformat/nexus/remote.py
+++ b/src/nexusformat/nexus/remote.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python 
+# -*- coding: utf-8 -*-
+
+"""
+This package provides a Python API that subclasses the 
+nexusformat package to work with HDF5 files served by h5serv. 
+
+"""
+from __future__ import (absolute_import, division, print_function)
+import six
+
+import os
+
+import numpy as np
+import h5pyd as h5
+
+from nexusformat.nexus import *
+
+NX_SERVER = 'hdfgroup.org:5000'
+__all__ = ['NXRemoteFile', 'nxloadremote']
+
+class NXRemoteFile(NXFile):
+
+    """
+    Structure-based interface to the NeXus file API.
+
+    Usage::
+
+      file = NXFile(filename, ['r','rw','w'])
+        - open the NeXus file
+      root = file.readfile()
+        - read the structure of the NeXus file.  This returns a NeXus tree.
+      file.writefile(root)
+        - write a NeXus tree to the file.
+
+    Example::
+
+      nx = NXFile('REF_L_1346.nxs','r')
+      tree = nx.readfile()
+      for entry in tree.NXentry:
+          process(entry)
+      copy = NXFile('modified.nxs','w')
+      copy.writefile(tree)
+
+    Note that the large datasets are not loaded immediately.  Instead, the
+    when the data set is requested, the file is reopened, the data read, and
+    the file closed again.  open/close are available for when we want to
+    read/write slabs without the overhead of moving the file cursor each time.
+    The :class:`NXdata` objects in the returned tree hold the object values.
+    """
+
+    def __init__(self, name, mode='r', server=NX_SERVER,  **kwds):
+        """
+        Creates an h5py File object for reading and writing.
+        """
+        self.h5 = h5
+        self.name = name
+        self._mode = 'r'
+        self._server = server
+        self._file = self.h5.File(self.domain, mode, endpoint=server)
+        self._filename = self.domain                             
+        self._path = '/'
+
+    def __repr__(self):
+        return '<NXRemoteFile "%s" (mode %s)>' % (self._filename,
+                                                  self._mode)
+
+    def open(self, **kwds):
+        if not self.isopen():
+            self._file = self.h5.File(self._filename,self._mode, 
+                                      endpoint=self._server)
+            self.nxpath = '/'
+        return self
+
+    def close(self):
+        if self.isopen():
+            self._file.close()
+
+    def isopen(self):
+        if self._file.id.uuid != 0:
+            return True
+        else:
+            return False
+
+    @property
+    def domain(self):
+        domain = self.name.split('.')[0].split('/')
+        domain.reverse()
+        domain.append('exfac')
+        return '.'.join(domain)
+
+    @property
+    def file(self):
+        if not self.isopen():
+            self.open()
+        return self._file
+
+    def readfile(self):
+        """
+        Reads the NeXus file structure from the file and returns a tree of 
+        NXobjects.
+
+        Large datasets are not read until they are needed.
+        """
+        self.nxpath = '/'
+        root = self._readgroup('root', self._file['/'])
+        root._group = None
+        root._file = self
+        root._filename = self._filename
+        root._mode = self._mode
+        return root
+
+    def _readattrs(self):
+        return dict(self[self.nxpath].attrs.items())
+
+    def _readchildren(self):
+        children = {}
+        for name, value in self._file[self.nxpath].items():
+            self.nxpath = self.nxpath + '/' + name
+            if isinstance(value, self.h5.Group):
+                children[name] = self._readgroup(name, value)
+            else:
+                children[name] = self._readdata(name, value)
+            self.nxpath = self.nxparent
+        return children
+
+    def _readgroup(self, name, group):
+        """
+        Reads the group with the current path and returns it as an NXgroup.
+        """
+        if group is None:
+            return NXgroup(name=name)
+        attrs = self._readattrs()
+        nxclass = self._readnxclass(attrs)
+        if nxclass is not None:
+            del attrs['NX_class']
+        elif self.nxpath == '/':
+            nxclass = 'NXroot'
+        else:
+            nxclass = 'NXgroup'
+        children = self._readchildren()
+        group = NXgroup(nxclass=nxclass, name=name, attrs=attrs, 
+                        entries=children)
+        for obj in children.values():
+            obj._group = group
+        group._changed = True
+        return group
+
+    def _readdata(self, name, field):
+        """
+        Reads a data object and returns it as an NXfield or NXlink.
+        """
+        if field is None:
+            return NXfield(name=name)
+        value, shape, dtype, attrs = self.readvalues(field)
+        if 'target' in attrs and self.nxpath != 'target':
+            return NXlinkfield(value=value, name=name, dtype=dtype, shape=shape, 
+                               target=self.attrs['target'], attrs=attrs)
+        else:
+            return NXfield(value=value, name=name, dtype=dtype, shape=shape, 
+                           attrs=attrs)
+ 
+    def readvalues(self, field):
+        shape, dtype = field.shape, field.dtype
+        if shape == (1,):
+            shape = ()
+        #Read in the data if it's not too large
+        if np.prod(shape) < 1000:# i.e., less than 1k dims
+            try:
+                value = field[()]
+                if isinstance(value, np.ndarray) and value.shape == (1,):
+                    value = np.asscalar(value)
+            except ValueError:
+                value = None
+        else:
+            value = None
+        attrs = self.attrs
+        return value, shape, dtype, attrs
+
+
+def loadremote(filename, endpoint='http://34.193.81.207:5000', mode='r'):
+    """
+    Reads a remote NeXus file returning a tree of objects.
+    """
+    with NXRemoteFile(filename, mode, endpoint) as f:
+        tree = f.readfile()
+    return tree
+
+nxloadremote = loadremote

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -2517,10 +2517,15 @@ class NXfield(NXobject):
             elif parent.nxgroup and 'title' in parent.nxgroup:
                 return text(parent.nxgroup.title)        
         else:
-            if self.nxroot.nxname != '' and self.nxroot.nxname != 'root':
-                return (self.nxroot.nxname + '/' + self.nxpath.lstrip('/')).rstrip('/')
+            root = self.nxroot
+            if root.nxname != '' and root.nxname != 'root':
+                return (root.nxname + '/' + self.nxpath.lstrip('/')).rstrip('/')
             else:
-                return self.nxfilename + ':' + self.nxpath
+                fname = self.nxfilename
+                if fname is not None:
+                    return fname + ':' + self.nxpath
+                else:
+                    return self.nxpath
 
     @property
     def mask(self):
@@ -3531,10 +3536,15 @@ class NXgroup(NXobject):
         elif self.nxgroup and 'title' in self.nxgroup:
             return text(self.nxgroup.title)
         else:
-            if self.nxroot.nxname != '' and self.nxroot.nxname != 'root':
-                return (self.nxroot.nxname + '/' + self.nxpath.lstrip('/')).rstrip('/')
+            root = self.nxroot
+            if root.nxname != '' and root.nxname != 'root':
+                return (root.nxname + '/' + self.nxpath.lstrip('/')).rstrip('/')
             else:
-                return self.nxfilename + ':' + self.nxpath
+                fname = self.nxfilename
+                if fname is not None:
+                    return fname + ':' + self.nxpath
+                else:
+                    return self.nxpath
 
     @property
     def entries(self):

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -254,8 +254,9 @@ string_dtype = h5.special_dtype(vlen=six.text_type)
 
 __all__ = ['NXFile', 'NXobject', 'NXfield', 'NXgroup', 'NXattr', 
            'NXlink', 'NXlinkfield', 'NXlinkgroup', 'NeXusError', 
-           'NX_MEMORY', 'nxsetmemory', 'NX_COMPRESSION', 'nxsetcompression',
-           'NX_ENCODING', 'nxsetencoding',
+           'NX_MEMORY', 'nxgetmemory', 'nxsetmemory', 
+           'NX_COMPRESSION', 'nxgetcompression', 'nxsetcompression',
+           'NX_ENCODING', 'nxgetencoding', 'nxsetencoding',
            'nxclasses', 'nxload', 'nxsave', 'nxduplicate', 'nxdir', 'nxdemo']
 
 #List of defined base classes (later added to __all__)
@@ -4793,6 +4794,15 @@ def centers(signal, axes):
             return axis.nxdata
     return [findc(a,signal.shape[i]) for i,a in enumerate(axes)]
 
+def getmemory():
+    """
+    Returns the memory limit for data arrays (in MB).
+    """
+    global NX_MEMORY
+    return NX_MEMORY
+
+nxgetmemory = getmemory
+
 def setmemory(value):
     """
     Sets the memory limit for data arrays (in MB).
@@ -4801,6 +4811,15 @@ def setmemory(value):
     NX_MEMORY = value
 
 nxsetmemory = setmemory
+
+def getcompression():
+    """
+    Returns default compression filter.
+    """
+    global NX_COMPRESSION
+    return NX_COMPRESSION
+
+nxgetcompression = getcompression
 
 def setcompression(value):
     """
@@ -4812,6 +4831,15 @@ def setcompression(value):
     NX_COMPRESSION = value
 
 nxsetcompression = setcompression
+
+def getencoding():
+    """
+    Returns the default encoding for input strings (usually 'utf-8').
+    """
+    global NX_ENCODING
+    return NX_ENCODING
+
+nxgetencoding = getencoding
 
 def setencoding(value):
     """


### PR DESCRIPTION
* This is the first commit of `remote.py`, which subclasses the NXFile class to utilize `h5pyd` to load files stored on a remote server, running `h5serv` or, in the future, `HSDS`, both HDF5 projects.
* Fixes a bug when plotting data in an unsaved root group.
* Fixes a bug when plotting data with bin boundaries sliced with an unlimited maximum value.