### PR TITLE
Change link mode

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,10 +1,10 @@
 package:
   name: nexusformat
-  version: "0.4.6"
+  version: "0.4.7"
 
 source:
   git_url: https://github.com/nexpy/nexusformat.git
-  git_tag: v0.4.6
+  git_tag: v0.4.7
 
 build:
   entry_points:

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -3571,7 +3571,8 @@ class NXlink(NXobject):
         self._name = name
         self._group = group
         self._abspath = abspath
-        self._mode = 'r'
+        if file is not None:
+            self._mode = 'r'
         self._attrs = AttrDict(self)
         self._entries = {}
         if isinstance(target, NXobject):

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -3093,8 +3093,6 @@ class NXgroup(NXobject):
         """
         Adds or modifies an item in the NeXus group.
         """
-        if self.nxfilemode == 'r':
-            raise NeXusError('NeXus file opened as readonly')
         if is_text(key):
             group = self
             if '/' in key:
@@ -3105,6 +3103,8 @@ class NXgroup(NXobject):
                         group = group[name]
                     else:
                         raise NeXusError('Invalid path')
+            if group.nxfilemode == 'r':
+                raise NeXusError('NeXus group marked as readonly')
             if key in group and isinstance(group.entries[key], NXlink):
                 raise NeXusError("Cannot assign values to an NXlink object")
             if isinstance(value, NXroot):


### PR DESCRIPTION
* Before the file mode had been set to read-only for all NXlink objects, even those linked to other objects in the same file. Now, only external links are read-only. Others inherit their mode from their parent groups.
* It is possible for the file mode of a subgroup to differ from the parent group, so it is necessary to determine the group being modified before checking the file mode.