### PR TITLE
try the read, so a fail doesn't stop read of tree

### DIFF
--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -714,9 +714,13 @@ class NXFile(object):
     def readvalue(self, path, idx=()):
         field = self.get(path)
         if field is not None:
-            return field[idx]
-        else:
-            return None
+            try:
+                return field[idx]
+            except IOError:
+                #print("Error: Could not read" + path)
+                pass
+                
+        return None
 
     def writevalue(self, path, value, idx=()):
         self[path][idx] = value


### PR DESCRIPTION
We have noticed that some data written into HDF5 not through python produces string datasets that cannot be read through h5py (example in [here](https://github.com/nexusformat/exampledata/tree/master/DLS/p45)).

A simple try except in readvalue would allow the tree to be printed even when a dataset read fails.

This change swallows the error, but I included commented code that would print the path to the problematic dataset.