### PR TITLE
Fix linked field plots

### DIFF
--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -3687,11 +3687,16 @@ class NXlink(NXobject):
 
     @property
     def attrs(self):
-        return self.nxlink.attrs
+        if self is not self.nxlink:
+            return self.nxlink.attrs
+        else:
+            return self.attrs
 
     def plot(self, **opts):
-        self.nxlink.plot(**opts)
-
+        if self is not self.nxlink:
+            self.nxlink.plot(**opts)
+        else:
+            self.plot(**opts)
 
 class NXlinkfield(NXlink, NXfield):
 

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -2694,11 +2694,14 @@ class NXfield(NXobject):
             return False
 
     @property
-    def plot_shape(self):     
-        _shape = list(self.shape)
-        while 1 in _shape:
-            _shape.remove(1)
-        return tuple(_shape)
+    def plot_shape(self):
+        try:  
+            _shape = list(self.shape)
+            while 1 in _shape:
+                _shape.remove(1)
+            return tuple(_shape)
+        except Exception:
+            return ()
 
     @property
     def plot_rank(self):


### PR DESCRIPTION
This fixes a problem when plotting NXdata groups that contain links. The temporary groups created during the plotting may not resolve the links properly. 