### PR TITLE
Fix regex error

### DIFF
--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -962,7 +962,7 @@ def _readaxes(axes):
     The delimiter separating each axis can be white space, a comma, or a colon.
     """
     if is_text(axes):
-        return list(re.split(r'[,:; ]', axes.strip('[]()')))
+        return list(re.split(r'[,:; ]', axes.strip('[]()').replace('][', ':')))
     else:
         return list(axes)
 

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -962,7 +962,7 @@ def _readaxes(axes):
     The delimiter separating each axis can be white space, a comma, or a colon.
     """
     if is_text(axes):
-        return list(re.split(r'[,:; \[\]]?', axes))
+        return list(re.split(r'[,:; ]', axes.strip('[]()')))
     else:
         return list(axes)
 


### PR DESCRIPTION
With Python 3, the current parsing of axis strings generates a future error warning, since the split string can be empty. This fixes it, and also handles other axis patterns, e.g., ['x','y'] and ['x']['y'].