### PR TITLE
Improve trees

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,10 +1,10 @@
 package:
   name: nexusformat
-  version: "0.4.8"
+  version: "0.4.10"
 
 source:
   git_url: https://github.com/nexpy/nexusformat.git
-  git_tag: v0.4.8
+  git_tag: v0.4.10
 
 build:
   entry_points:

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -3185,8 +3185,12 @@ class NXgroup(NXobject):
                     raise NeXusError(
                         "The value is incompatible with the current entry")
             elif isinstance(value, NXlink):
-                value = NXlink(target=value._target, file=value._filename,
-                               name=key, group=group)
+                if group.nxfilename != value.nxfilename:
+                    value = NXlink(target=value._target, file=value.nxfilename,
+                                   name=key, group=group)
+                else:
+                    value = NXlink(target=value._target, file=value._filename,
+                                   name=key, group=group)
                 group.entries[key] = value
             elif isinstance(value, NXobject):
                 if value.nxgroup:

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -3079,7 +3079,8 @@ class NXgroup(NXobject):
         self.set_changed()
 
     def __dir__(self):
-        return sorted(dir(super(self.__class__, self))+list(self))
+        return sorted(dir(super(self.__class__, self))+list(self), 
+                      key=natural_sort)
 
     def __repr__(self):
         return "%s('%s')" % (self.__class__.__name__,self.nxname)
@@ -3591,7 +3592,7 @@ class NXgroup(NXobject):
             result.append(self._str_attrs(indent=indent+2))
         entries = self.entries
         if entries:
-            names = sorted(entries)
+            names = sorted(entries, key=natural_sort)
             if recursive:
                 if recursive is True or recursive >= indent:
                     for k in names:

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -3813,8 +3813,8 @@ class NXlinkfield(NXlink, NXfield):
         if self._filename is None:
             return self.nxlink._get_filedata(idx)
         else:
-            with NXFile(self._filename, 'r') as f:
-                result = f.readvalue(self._target, idx=idx)
+            with NXFile(self.nxfilename, 'r') as f:
+                result = f.readvalue(self.nxtarget, idx=idx)
             return result
 
     @property
@@ -3823,7 +3823,7 @@ class NXlinkfield(NXlink, NXfield):
             if self.nxfilename != self.nxroot.nxfilename:
                 return self
             else:
-               return self.nxroot[self._target]
+               return self.nxroot[self.nxtarget]
         except Exception:
             return self
 

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -2441,8 +2441,6 @@ class NXfield(NXobject):
         s = text(self)
         if ((self.dtype == string_dtype or self.dtype.kind == 'S')
             and len(self) == 1):
-            if s.startswith('u'):
-                s = s[1:]
             if len(s) > 60:
                 s = s[0:56] + '...'
             s = "'" + s + "'"

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -1287,7 +1287,7 @@ class NXobject(object):
         It invokes the 'dir' method with 'attrs' set to False and 'recursive'
         set to True.
         """
-        return self._str_tree(attrs=False, recursive=3)
+        return self._str_tree(attrs=False, recursive=2)
 
     def rename(self, name):
         if self.nxgroup is not None and self.nxgroup.nxfilemode != 'r':
@@ -3593,7 +3593,7 @@ class NXgroup(NXobject):
         if entries:
             names = sorted(entries)
             if recursive:
-                if recursive > 1 and recursive > indent:
+                if recursive is True or recursive >= indent:
                     for k in names:
                         result.append(entries[k]._str_tree(indent=indent+2,
                                                            attrs=attrs, 

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -1287,7 +1287,7 @@ class NXobject(object):
         It invokes the 'dir' method with 'attrs' set to False and 'recursive'
         set to True.
         """
-        return self._str_tree(attrs=False, recursive=True)
+        return self._str_tree(attrs=False, recursive=3)
 
     def rename(self, name):
         if self.nxgroup is not None and self.nxgroup.nxfilemode != 'r':
@@ -3593,10 +3593,11 @@ class NXgroup(NXobject):
         if entries:
             names = sorted(entries)
             if recursive:
-                for k in names:
-                    result.append(entries[k]._str_tree(indent=indent+2,
-                                                       attrs=attrs, 
-                                                       recursive=True))
+                if recursive > 1 and recursive > indent:
+                    for k in names:
+                        result.append(entries[k]._str_tree(indent=indent+2,
+                                                           attrs=attrs, 
+                                                           recursive=recursive))
             else:
                 for k in names:
                     result.append(entries[k]._str_name(indent=indent+2))

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -3809,6 +3809,14 @@ class NXlinkfield(NXlink, NXfield):
         return NXfield._str_tree(self, indent=indent, attrs=attrs, 
                                  recursive=recursive)
 
+    def _get_filedata(self, idx=()):
+        if self._filename is None:
+            return self.nxlink._get_filedata(idx)
+        else:
+            with NXFile(self._filename, 'r') as f:
+                result = f.readvalue(self._target, idx=idx)
+            return result
+
     @property
     def nxlink(self):
         try:

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -2442,7 +2442,11 @@ class NXfield(NXobject):
         if ((self.dtype == string_dtype or self.dtype.kind == 'S')
             and len(self) == 1):
             if len(s) > 60:
-                s = s[0:56] + '...'
+                s = s[:56] + '...'
+            try:
+                s = s[:s.index('\n')]+'...'
+            except ValueError:
+                pass
             s = "'" + s + "'"
         elif len(self) > 3 or '\n' in s or s == "":
             s = "%s(%s)" % (self.dtype, dims)


### PR DESCRIPTION
This allows a recursion level to be set when printing trees. The `short_tree` function now uses a recursion level of 2. It also improves the handling of text NXfields with line feeds. These improvements will form part of meeting the suggested enhancements in NeXpy nexpy/nexpy#122.