### PR TITLE
Modify group assignments

### DIFF
--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -1913,6 +1913,25 @@ class NXfield(NXobject):
                 self._put_memdata(idx, value)
         self.set_changed()
 
+    def _str_name(self, indent=0):
+        dims = 'x'.join([text(n) for n in self.shape])
+        s = text(self)
+        if ((self.dtype == string_dtype or self.dtype.kind == 'S')
+            and len(self) == 1):
+            if len(s) > 60:
+                s = s[:56] + '...'
+            try:
+                s = s[:s.index('\n')]+'...'
+            except ValueError:
+                pass
+            s = "'" + s + "'"
+        elif len(self) > 3 or '\n' in s or s == "":
+            s = "%s(%s)" % (self.dtype, dims)
+        try:
+            return " " * indent + self.nxname + " = " + s
+        except Exception:
+            return " " * indent + self.nxname
+
     def _get_filedata(self, idx=()):
         with self.nxfile as f:
             result = f.readvalue(self.nxpath, idx=idx)
@@ -2445,31 +2464,12 @@ class NXfield(NXobject):
         except ImportError:
             raise NeXusError("No conversion utility available")
         if self._value is not None:
-            return self._converter(self._value,units)
+            return self._converter(self._value, units)
         else:
             return None
 
     def walk(self):
         yield self
-
-    def _str_name(self, indent=0):
-        dims = 'x'.join([text(n) for n in self.shape])
-        s = text(self)
-        if ((self.dtype == string_dtype or self.dtype.kind == 'S')
-            and len(self) == 1):
-            if len(s) > 60:
-                s = s[:56] + '...'
-            try:
-                s = s[:s.index('\n')]+'...'
-            except ValueError:
-                pass
-            s = "'" + s + "'"
-        elif len(self) > 3 or '\n' in s or s == "":
-            s = "%s(%s)" % (self.dtype, dims)
-        try:
-            return " " * indent + self.nxname + " = " + s
-        except Exception:
-            return " " * indent + self.nxname
 
     def replace(self, value):
         """

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -2483,8 +2483,9 @@ class NXfield(NXobject):
         if group is None:
             raise NeXusError("The field must be a member of a group")
         if isinstance(value, NXfield):
-            value = value.nxdata
-        if is_text(value):
+            del group[self.nxname]
+            group[self.nxname] = value
+        elif is_text(value):
             if self.dtype == string_dtype:
                 self.nxdata = value
             else:

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -2073,12 +2073,11 @@ class NXfield(NXobject):
         dpcpy._fillvalue = copy(obj.fillvalue)
         dpcpy._maxshape = copy(obj.maxshape)
         dpcpy._changed = True
-        dpcpy._memfile = None
-        dpcpy._uncopied_data = None
+        dpcpy._memfile = obj._memfile
+        dpcpy._uncopied_data = obj._uncopied_data
         if obj._value is not None:
             dpcpy._value = copy(obj._value)
-        elif obj._memfile:
-            dpcpy._memfile = obj._memfile
+            dpcpy._memfile = dpcpy._uncopied_data = None
         elif obj.nxfilemode:
             dpcpy._uncopied_data = (obj.nxfile, obj.nxpath)
         for k, v in obj.attrs.items():

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -3198,17 +3198,9 @@ class NXgroup(NXobject):
                         "Cannot assign an NXlink to an existing group entry")
                 elif isinstance(group.entries[key], NXlink):
                     raise NeXusError("Cannot assign values to an NXlink")
-                try:                
-                    if isinstance(value, NXfield):
-                        if (group.nxfilemode and not 
-                            value.is_compatible(group.entries[key])):
-                            raise NeXusError("Incompatible fields")
-                        group.entries[key].copy_field(value)
-                    else:
-                        group.entries[key].nxdata = value
-                except NeXusError:
-                    raise NeXusError(
-                        "The value is incompatible with the current entry")
+                group.entries[key].nxdata = value
+                if isinstance(value, NXfield):
+                    group.entries[key]._setattrs(value.attrs)
             elif isinstance(value, NXlink):
                 if group.nxfilename != value.nxfilename:
                     value = NXlink(target=value._target, file=value.nxfilename,

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -2410,19 +2410,6 @@ class NXfield(NXobject):
     def T(self):
         return self.transpose()
 
-    def is_compatible(self, field):
-        return (self.dtype == field.dtype) and (self.shape == field.shape)
-
-    def copy_field(self, field):
-        if field._value is not None:
-            self._value = field._value
-        elif field._memfile:
-            self._memfile = field._memfile
-        elif field.nxfilemode:
-            self._uncopied_data = (field.nxfile, field.nxpath)
-        for k, v in field.attrs.items():
-            self.attrs[k] = v
-
     def centers(self):
         """
         Returns an NXfield with the centers of a single axis

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -2039,7 +2039,7 @@ class NXfield(NXobject):
                 f.copy(_path, self._memfile, 'data')
         self._uncopied_data = None
 
-    def __deepcopy__(self, memo):
+    def __deepcopy__(self, memo={}):
         if isinstance(self, NXlink):
             obj = self.nxlink
         else:
@@ -2049,6 +2049,10 @@ class NXfield(NXobject):
         dpcpy._name = copy(obj.nxname)
         dpcpy._dtype = copy(obj.dtype)
         dpcpy._shape = copy(obj.shape)
+        dpcpy._chunks = copy(obj.chunks)
+        dpcpy._compression = copy(obj.compression)
+        dpcpy._fillvalue = copy(obj.fillvalue)
+        dpcpy._maxshape = copy(obj.maxshape)
         dpcpy._changed = True
         dpcpy._memfile = None
         dpcpy._uncopied_data = None


### PR DESCRIPTION
A previous PR disallowed assignments of NXfields to an existing field in the group. However, that is too restrictive, so the current version allows it if the values are compatible (as determined by setting the `nxdata` property. It also improves the `__deepcopy__` function, which is now invoked by the NXfield `replace` function. 