### PR TITLE
Fix renames

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,10 +1,10 @@
 package:
   name: nexusformat
-  version: "0.4.10"
+  version: "0.4.11"
 
 source:
   git_url: https://github.com/nexpy/nexusformat.git
-  git_tag: v0.4.10
+  git_tag: v0.4.11
 
 build:
   entry_points:

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -1447,18 +1447,15 @@ class NXobject(object):
 
     @property
     def nxpath(self):
-        if self.nxclass == 'NXroot':
-            return "/"
-        elif self.nxgroup is None:
+        group = self.nxgroup
+        if group is None:
             return self.nxname
-        elif isinstance(self.nxgroup, NXroot):
+        elif self.nxclass == 'NXroot':
+            return "/"
+        elif isinstance(group, NXroot):
             return "/" + self.nxname
         else:
-            group_path = self.nxgroup.nxpath
-            if group_path:
-                return group_path+"/"+self.nxname
-            else:
-                return self.nxname
+            return group.nxpath+"/"+self.nxname
 
     @property
     def nxroot(self):

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -1301,8 +1301,7 @@ class NXobject(object):
             if group.nxfilemode == 'rw':
                 with group.nxfile as f:
                     f.rename(old_path, new_path)
-            group.entries[name] = group.entries[self._name]
-            del group.entries[name]
+            group.entries[name] = group.entries.pop(self._name)
             if self is signal:
                 group.nxsignal = self
             elif axes is not None:

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -1298,8 +1298,9 @@ class NXobject(object):
         old_path = self.nxpath
         if group is not None:
             new_path = group.nxpath + '/' + name
-            with group.nxfile as f:
-                f.rename(old_path, new_path)
+            if group.nxfilemode == 'rw':
+                with group.nxfile as f:
+                    f.rename(old_path, new_path)
             group.entries[name] = group.entries[self._name]
             del group.entries[name]
             if self is signal:

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -1450,7 +1450,7 @@ class NXobject(object):
         if self.nxclass == 'NXroot':
             return "/"
         elif self.nxgroup is None:
-            return ""
+            return self.nxname
         elif isinstance(self.nxgroup, NXroot):
             return "/" + self.nxname
         else:


### PR DESCRIPTION
The rename function incorrectly assumed that the data had been saved to a NeXus file already. This fixes that and improves the nxpath property.