### PR TITLE
Minor enhancements and bug fixes

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include versioneer.py
 include src/nexusformat/_version.py
+include src/notebooks/*.ipynb

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -1781,6 +1781,8 @@ class NXfield(NXobject):
                     value = slab.get([i,j,0],size)
 
     """
+    properties = ['mask', 'dtype', 'shape', 'compression', 'fillvalue', 
+                  'chunks', 'maxshape']
 
     def __init__(self, value=None, name='field', dtype=None, shape=None, 
                  group=None, attrs=None, **attr):
@@ -1856,7 +1858,8 @@ class NXfield(NXobject):
         name starts with 'nx' or '_', or unless it is one of the standard Python
         attributes for the NXfield class.
         """
-        if name.startswith('_') or name.startswith('nx'):
+        if (name.startswith('_') or name.startswith('nx') or 
+            name in self.properties):
             object.__setattr__(self, name, value)
         elif self.nxfilemode == 'r':
             raise NeXusError("NeXus file opened as readonly")
@@ -4399,7 +4402,7 @@ class NXdata(NXgroup):
             result = NXdata(signal, axes, errors, *removed_axes)
             if errors is not None:
                 result.nxerrors = errors
-            if signal.mask:
+            if signal.mask is not None:
                 result[signal.mask.nxname] = signal.mask           
             if self.nxtitle:
                 result.title = self.nxtitle

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -1250,7 +1250,7 @@ class NXobject(object):
         Prints the current object and children (if any).
         """
         result = [self._str_name(indent=indent)]
-        if attrs and self.attrs:
+        if self.attrs and (attrs or indent==0):
             result.append(self._str_attrs(indent=indent+2))
         return "\n".join(result)
 
@@ -3661,7 +3661,7 @@ class NXgroup(NXobject):
         Prints the current object and children (if any).
         """
         result = [self._str_name(indent=indent)]
-        if attrs and self.attrs:
+        if self.attrs and (attrs or indent==0):
             result.append(self._str_attrs(indent=indent+2))
         entries = self.entries
         if entries:

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -1535,6 +1535,12 @@ class NXobject(object):
     def is_external(self):
         return (self.nxfilename is not None and 
                 self.nxfilename != self.nxroot.nxfilename)
+    
+    def exists(self):
+        if self.nxfilename is not None:
+            return os.path.exists(self.nxfilename)
+        else:
+            return True
 
 
 class NXfield(NXobject):
@@ -2841,6 +2847,9 @@ class NXfield(NXobject):
 
         Raises NeXusError if the data could not be plotted.
         """
+        if not self.exists():
+            raise NeXusError("'%s' does not exist" % 
+                             os.path.abspath(self.nxfilename))
 
         try:
             from __main__ import plotview
@@ -4735,6 +4744,14 @@ class NXdata(NXgroup):
         Raises NeXusError if the data could not be plotted.
         """
 
+        # Check there is a plottable signal
+        if self.nxsignal is None:
+            raise NeXusError("No plotting signal defined")
+        elif not self.nxsignal.exists():
+            raise NeXusError("'%s' does not exist" % 
+                             os.path.abspath(self.nxfilename))
+
+        # Plot with the available plotter
         try:
             from __main__ import plotview
             if plotview is None:
@@ -4742,11 +4759,6 @@ class NXdata(NXgroup):
         except ImportError:
             from .plot import plotview
             
-        # Check there is a plottable signal
-        if self.nxsignal is None:
-            raise NeXusError("No plotting signal defined")
-
-        # Plot with the available plotter
         plotview.plot(self, fmt, xmin, xmax, ymin, ymax, zmin, zmax, **opts)
     
     def oplot(self, fmt='', **opts):

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -4370,6 +4370,18 @@ class NXdata(NXgroup):
             self["errors"] = errors
         self.attrs._setattrs(attrs)
 
+    def __setattr__(self, name, value):
+        """
+        Sets an attribute as an object or regular Python attribute.
+
+        This calls the NXgroup __setattr__ function unless the name is 'mask'
+        which is used to set signal masks.
+        """
+        if name == 'mask':
+            object.__setattr__(self, name, value)
+        else:
+            super(NXdata, self).__setattr__(name, value)
+
     def __getitem__(self, key):
         """
         Returns an entry in the group if the key is a string.
@@ -4882,6 +4894,25 @@ class NXdata(NXgroup):
             name = 'errors'
         self[name] = errors
         return self.entries[name]
+
+    @property
+    def mask(self):
+        """Returns the signal mask if one exists."""
+        if self.nxsignal is not None:
+            return self.nxsignal.mask
+        else:
+            return None
+
+    @mask.setter
+    def mask(self, value):
+        """Sets a value for the signal mask if it exists.
+        
+        This can only be used with a value of np.ma.nomask to remove the mask.
+        """
+        if value is np.ma.nomask and self.nxsignal.mask is not None:
+            self.nxsignal.mask = np.ma.nomask
+            if isinstance(self.nxsignal.mask, NXfield):
+                del self[self.nxsignal.mask.nxname]
 
 
 class NXmonitor(NXdata):

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -3521,13 +3521,14 @@ class NXgroup(NXobject):
             axes = self.nxaxes
             averages = []
             for ax in axis:
-                summedaxis = deepcopy(axes.pop(ax))
+                summedaxis = deepcopy(axes[ax])
                 summedaxis.attrs["minimum"] = summedaxis.nxdata[0]
                 summedaxis.attrs["maximum"] = summedaxis.nxdata[-1]
                 summedaxis.attrs["summed_bins"] = summedaxis.size
                 averages.append(NXfield(
                     0.5*(summedaxis.nxdata[0]+summedaxis.nxdata[-1]), 
                     name=summedaxis.nxname,attrs=summedaxis.attrs))
+            axes = [axes[i] for i in range(len(axes)) if i not in axis]
             result = NXdata(signal, axes)
             summed_bins = 1
             for average in averages:

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -4048,14 +4048,25 @@ class NXroot(NXgroup):
     def lock(self):
         """Make the tree readonly"""
         if self._filename:
-            self._mode = self._file.mode = 'r'
-            self.set_changed()
+            if self.exists():
+                self._mode = self._file.mode = 'r'
+                self.set_changed()
+            else:
+                raise NeXusError("'%s' does not exist" % 
+                                 os.path.abspath(self.nxfilename))
 
     def unlock(self):
         """Make the tree modifiable"""
         if self._filename:
-            self._mode = self._file.mode = 'rw'
-            self.set_changed()
+            if self.exists():
+                self._mode = self._file.mode = 'rw'
+                self.set_changed()
+            else:
+                self._mode = None
+                self._file = None
+                self.set_changed()
+                raise NeXusError("'%s' does not exist" % 
+                                 os.path.abspath(self.nxfilename))
 
     def backup(self, filename=None, dir=None):
         """Backup the NeXus file.

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -4422,7 +4422,8 @@ class NXdata(NXgroup):
             if errors is not None:
                 result.nxerrors = errors
             if self.nxsignal.mask is not None:
-                result[self.nxsignal.mask.nxname] = signal.mask           
+                if isinstance(self.nxsignal.mask, NXfield):
+                    result[self.nxsignal.mask.nxname] = signal.mask 
             if self.nxtitle:
                 result.title = self.nxtitle
             return result
@@ -4913,6 +4914,8 @@ class NXdata(NXgroup):
             self.nxsignal.mask = np.ma.nomask
             if isinstance(self.nxsignal.mask, NXfield):
                 del self[self.nxsignal.mask.nxname]
+            if 'mask' in self.nxsignal.attrs:
+                del self.nxsignal.attrs['mask']
 
 
 class NXmonitor(NXdata):

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -1216,7 +1216,7 @@ class NXobject(object):
     def __repr__(self):
         return "NXobject('%s','%s')" % (self.nxclass, self.nxname)
 
-    def __contains__(self):
+    def __contains__(self, key):
         return None
 
     def _setattrs(self, attrs):


### PR DESCRIPTION
* Adds ability to use NXdata slicing to set and remove masks. This also removes the mask attribute and field from the signal when none of the data is masked and fixes a bug in setting masks.
* Modifies the `short_tree` function to display the attributes of the first item. This makes the NeXpy tree tooltips more useful, without increasing their length substantially.
* Improves handling of externally linked data pointing to non-existent files.
* Fixes a bug setting NXfield properties.
* Fixes a bug using the NXfield sum command with multiple axes.