### PR TITLE
Bug fixes and enhancements

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,10 +1,10 @@
 package:
   name: nexusformat
-  version: "0.4.14"
+  version: "0.4.15"
 
 source:
   git_url: https://github.com/nexpy/nexusformat.git
-  git_tag: v0.4.14
+  git_tag: v0.4.15
 
 build:
   entry_points:

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -3268,10 +3268,10 @@ class NXgroup(NXobject):
             elif isinstance(value, NXlink):
                 if group.nxfilename != value.nxfilename:
                     value = NXlink(target=value._target, file=value.nxfilename,
-                                   name=key, group=group)
+                                   abspath=value.abspath, name=key, group=group)
                 else:
                     value = NXlink(target=value._target, file=value._filename,
-                                   name=key, group=group)
+                                   abspath=value.abspath, name=key, group=group)
                 group.entries[key] = value
             elif isinstance(value, NXobject):
                 value = deepcopy(value)

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -2602,7 +2602,7 @@ class NXfield(NXobject):
         """
         plot_axes = [axis for axis in axes if axis.size > 1]
         axis_shape = [axis.size for axis in plot_axes]
-        if (all(i == 1 for i in plot_axes.ndim) and 
+        if (all(axis.ndim == 1 for axis in plot_axes) and 
             len([x for x,y in zip(self.plot_shape, axis_shape) 
                  if x==y or x==y-1]) == self.plot_rank):
             return True

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -3280,6 +3280,9 @@ class NXgroup(NXobject):
                         field._memfile.copy('mask', group[mask_name]._memfile, 
                                             'data')
                         del field._memfile['mask']
+            elif (isinstance(group.entries[key], NXentry) and 
+                  not isinstance(group, NXroot)):
+                  group.entries[key].nxclass = NXsubentry
             group.entries[key].update()
         else:
             raise NeXusError("Invalid key")
@@ -3475,8 +3478,7 @@ class NXgroup(NXobject):
                 name = value.nxname
             if name in self.entries:
                 raise NeXusError("'%s' already exists in group" % name)
-            self.entries[name] = deepcopy(value)
-            self.entries[name].nxgroup = self
+            self[name] = value
             self.update()
         else:
             if name in self.entries:

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -1790,7 +1790,7 @@ class NXfield(NXobject):
     properties = ['mask', 'dtype', 'shape', 'compression', 'fillvalue', 
                   'chunks', 'maxshape']
 
-    def __init__(self, value=None, name='field', dtype=None, shape=None, 
+    def __init__(self, value=None, name='unknown', dtype=None, shape=None, 
                  group=None, attrs=None, **attr):
         self._class = 'NXfield'
         self._name = name
@@ -4352,7 +4352,7 @@ class NXdata(NXgroup):
     """
 
     def __init__(self, signal=None, axes=None, errors=None, *items, **opts):
-        self._class = "NXdata"
+        self._class = 'NXdata'
         NXgroup.__init__(self, *items, **opts)
         attrs = {}
         if axes is not None:
@@ -4363,27 +4363,35 @@ class NXdata(NXgroup):
             for axis in axes:
                 i += 1
                 if isinstance(axis, NXfield) or isinstance(axis, NXlink):
-                    if axis._name == "unknown": 
-                        axis._name = "axis%s" % i
+                    if axis._name == 'unknown': 
+                        axis._name = 'axis%s' % i
                     self[axis.nxname] = axis
                     axis_names[i] = axis.nxname
                 else:
-                    axis_name = "axis%s" % i
+                    axis_name = 'axis%s' % i
                     self[axis_name] = axis
                     axis_names[i] = axis_name
-            attrs["axes"] = list(axis_names.values())
+            attrs['axes'] = list(axis_names.values())
         if signal is not None:
             if isinstance(signal, NXfield) or isinstance(signal, NXlink):
-                if signal.nxname == "unknown" or signal.nxname in self:
-                    signal.nxname = "signal"
-                self[signal.nxname] = signal
-                signal_name = signal.nxname
+                if signal.nxname == 'unknown' or signal.nxname in self:
+                    signal_name = 'signal'
+                else:
+                    signal_name = signal.nxname
             else:
-                self["signal"] = signal
-                signal_name = "signal"
-            attrs["signal"] = signal_name
-        if errors is not None:
-            self["errors"] = errors
+                signal_name = 'signal'
+            self[signal_name] = signal
+            attrs['signal'] = signal_name
+            if errors is not None:
+                if isinstance(errors, NXfield):
+                    if errors.nxname == 'unknown' or errors.nxname in self:
+                        errors_name = signal_name+'_errors'
+                    else:
+                        errors_name = errors.nxname
+                else:
+                    errors_name = signal_name+'_errors'
+                self[errors_name] = errors
+                self[signal_name].attrs['uncertainties'] = errors_name
         self.attrs._setattrs(attrs)
 
     def __setattr__(self, name, value):

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -263,18 +263,19 @@ __all__ = ['NXFile', 'NXobject', 'NXfield', 'NXgroup', 'NXattr',
            'nxversion']
 
 #List of defined base classes (later added to __all__)
-nxclasses = [ 'NXroot', 'NXentry', 'NXsubentry', 'NXdata', 'NXmonitor', 'NXlog', 
-              'NXsample', 'NXinstrument', 'NXaperture', 'NXattenuator', 
-              'NXbeam', 'NXbeam_stop', 'NXbending_magnet', 'NXcapillary',
-              'NXcharacterization', 'NXcollection', 'NXcollimator', 'NXcrystal',
-              'NXdetector', 'NXdetector_group', 'NXdisk_chopper', 
-              'NXenvironment', 'NXevent_data', 'NXfermi_chopper', 'NXfilter', 
-              'NXflipper', 'NXgeometry', 'NXgoniometer', 'NXguide', 
-              'NXinsertion_device', 'NXmirror', 'NXmoderator', 
-              'NXmonochromator', 'NXnote', 'NXorientation', 'NXparameters', 
-              'NXpolarizer', 'NXpositioner', 'NXprocess', 'NXsensor', 'NXshape', 
-              'NXsource', 'NXsubentry', 'NXtranslation', 'NXuser', 
-              'NXvelocity_selector', 'NXxraylens']
+nxclasses = ['NXroot', 'NXentry', 'NXsubentry', 'NXdata', 'NXmonitor', 'NXlog', 
+             'NXsample', 'NXinstrument', 'NXaperture', 'NXattenuator', 'NXbeam', 
+             'NXbeam_stop', 'NXbending_magnet', 'NXcapillary', 'NXcite',
+             'NXcollection', 'NXcollimator', 'NXcrystal', 'NXdetector', 
+             'NXdetector_group', 'NXdetector_module', 'NXdisk_chopper', 
+             'NXenvironment', 'NXevent_data', 'NXfermi_chopper', 'NXfilter', 
+             'NXflipper', 'NXgeometry', 'NXgrating', 'NXgoniometer', 'NXguide', 
+             'NXinsertion_device', 'NXmirror', 'NXmoderator', 'NXmonochromator', 
+             'NXnote', 'NXorientation', 'NXparameters', 'NXpinhole', 
+             'NXpolarizer', 'NXpositioner', 'NXprocess', 'NXreflections', 
+             'NXsample_component', 'NXsensor', 'NXshape', 'NXslit', 'NXsource', 
+             'NXtransformations', 'NXtranslation', 'NXuser', 
+             'NXvelocity_selector', 'NXxraylens']
 
 
 def text(value):

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -572,6 +572,7 @@ class NXFile(object):
             if group.nxname not in self[self.nxparent]:
                 if group._target is not None:
                     if group._filename is not None:
+                        self.nxpath = self.nxparent
                         self._writeexternal(group)
                         self.nxpath = self.nxparent
                         return []

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -1492,7 +1492,14 @@ class NXobject(object):
     @property
     def nxfilename(self):
         if self._filename is not None:
-            return os.path.abspath(self._filename)
+            if os.path.isabs(self._filename):
+                return self._filename
+            elif self._group is not None:
+                return os.path.abspath(
+                    os.path.join(os.path.dirname(self._group.nxfilename),
+                                 self._filename))
+            else:
+                return os.path.abspath(self._filename)
         elif self._group is not None:
             return self._group.nxfilename
         else:
@@ -3828,20 +3835,6 @@ class NXlink(NXobject):
             return self
 
     @property
-    def nxfilename(self):
-        if self._filename is not None:
-            if (self is self.nxroot or self.nxroot.nxfilename is None or
-                   os.path.isabs(self._filename)):
-                return self._filename
-            else:
-                return os.path.abspath(os.path.join(
-                    os.path.dirname(self.nxroot.nxfilename), self._filename))
-        elif self._group is not None:
-            return self._group.nxfilename
-        else:
-            return None
-
-    @property
     def attrs(self):
         if not self.is_external():
             return self.nxlink._attrs
@@ -3855,6 +3848,10 @@ class NXlink(NXobject):
             except Exception:
                 pass
             return self._attrs
+
+    @property
+    def abspath(self):
+        return self._abspath
 
     def is_external(self):
         if self._external is None:

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -3325,7 +3325,7 @@ class NXgroup(NXobject):
         """
         Compares the entries dictionaries
         """
-        if other is None: 
+        if not isinstance(other, NXgroup): 
             return False
         elif id(self) == id(other):
             return True

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -3498,7 +3498,7 @@ class NXgroup(NXobject):
                 raise NeXusError("'%s' already exists in group" % name)
             self[name] = NXfield(value=value, name=name, group=self)
 
-    def makelink(self, target, name=None):
+    def makelink(self, target, name=None, abspath=False):
         """
         Creates a linked NXobject within the group.
 
@@ -3522,7 +3522,8 @@ class NXgroup(NXobject):
         if self.nxroot == target.nxroot:
             self[name] = NXlink(target=target)
         else:
-            self[name] = NXlink(target=target.nxpath, file=target.nxfilename)
+            self[name] = NXlink(target=target.nxpath, file=target.nxfilename,
+                                abspath=abspath)
  
     def sum(self, axis=None, averaged=False):
         """

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -1934,7 +1934,7 @@ class NXfield(NXobject):
             if isinstance(value, np.bool_) and self.dtype != np.bool_:
                 raise NeXusError(
                     "Cannot set a Boolean value to a non-Boolean data type")
-            elif value == np.ma.nomask:
+            elif value is np.ma.nomask:
                 value = False
             if self._value is not None:
                 self._value[idx] = value

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -4466,7 +4466,7 @@ class NXdata(NXgroup):
         elif self.nxsignal is not None:
             if isinstance(idx, numbers.Integral) or isinstance(idx, slice):
                 axis = self.nxaxes[0]
-                if self.nxsignal.shape[i] == axis.shape[0]:
+                if self.nxsignal.shape[0] == axis.shape[0]:
                     axis = axis.boundaries()
                 idx = convert_index(idx, axis)
                 self.nxsignal[idx] = value

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -4369,14 +4369,14 @@ class NXdata(NXgroup):
             for axis in axes:
                 i += 1
                 if isinstance(axis, NXfield) or isinstance(axis, NXlink):
-                    if axis._name == 'unknown': 
-                        axis._name = 'axis%s' % i
-                    self[axis.nxname] = axis
-                    axis_names[i] = axis.nxname
+                    if axis.nxname == 'unknown' or axis.nxname in self: 
+                        axis_name = 'axis%s' % i
+                    else:
+                        axis_name = axis.nxname
                 else:
                     axis_name = 'axis%s' % i
-                    self[axis_name] = axis
-                    axis_names[i] = axis_name
+                self[axis_name] = axis
+                axis_names[i] = axis_name
             attrs['axes'] = list(axis_names.values())
         if signal is not None:
             if isinstance(signal, NXfield) or isinstance(signal, NXlink):
@@ -4389,7 +4389,7 @@ class NXdata(NXgroup):
             self[signal_name] = signal
             attrs['signal'] = signal_name
             if errors is not None:
-                if isinstance(errors, NXfield):
+                if isinstance(errors, NXfield) or isinstance(errors, NXlink):
                     if errors.nxname == 'unknown' or errors.nxname in self:
                         errors_name = signal_name+'_errors'
                     else:

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -4363,10 +4363,7 @@ class NXdata(NXgroup):
                 if isinstance(axis, NXfield) or isinstance(axis, NXlink):
                     if axis._name == "unknown": 
                         axis._name = "axis%s" % i
-                    if isinstance(axis, NXlink):
-                        self[axis.nxname] = axis.nxlink
-                    else:
-                        self[axis.nxname] = axis
+                    self[axis.nxname] = axis
                     axis_names[i] = axis.nxname
                 else:
                     axis_name = "axis%s" % i
@@ -4377,10 +4374,7 @@ class NXdata(NXgroup):
             if isinstance(signal, NXfield) or isinstance(signal, NXlink):
                 if signal.nxname == "unknown" or signal.nxname in self:
                     signal.nxname = "signal"
-                if isinstance(signal, NXlink):
-                    self[signal.nxname] = signal.nxlink
-                else:
-                    self[signal.nxname] = signal
+                self[signal.nxname] = signal
                 signal_name = signal.nxname
             else:
                 self["signal"] = signal

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -1453,10 +1453,10 @@ class NXobject(object):
     @property
     def nxpath(self):
         group = self.nxgroup
-        if group is None:
-            return self.nxname
-        elif self.nxclass == 'NXroot':
+        if self.nxclass == 'NXroot':
             return "/"
+        elif group is None:
+            return self.nxname
         elif isinstance(group, NXroot):
             return "/" + self.nxname
         else:

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -244,6 +244,8 @@ import sys
 import numpy as np
 import h5py as h5
 
+from .. import __version__ as nxversion
+
 #Memory in MB
 NX_MEMORY = 2000
 NX_COMPRESSION = 'gzip'
@@ -257,7 +259,8 @@ __all__ = ['NXFile', 'NXobject', 'NXfield', 'NXgroup', 'NXattr',
            'NX_MEMORY', 'nxgetmemory', 'nxsetmemory', 
            'NX_COMPRESSION', 'nxgetcompression', 'nxsetcompression',
            'NX_ENCODING', 'nxgetencoding', 'nxsetencoding',
-           'nxclasses', 'nxload', 'nxsave', 'nxduplicate', 'nxdir', 'nxdemo']
+           'nxclasses', 'nxload', 'nxsave', 'nxduplicate', 'nxdir', 'nxdemo',
+           'nxversion']
 
 #List of defined base classes (later added to __all__)
 nxclasses = [ 'NXroot', 'NXentry', 'NXsubentry', 'NXdata', 'NXmonitor', 'NXlog', 

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -2919,10 +2919,10 @@ class NXfield(NXobject):
         if self.is_plottable():
             data = NXdata(self, self.nxaxes, title=self.nxtitle)
             if self.nxroot.nxclass == "NXroot":
-                label = self.nxroot.nxname + self.nxpath
+                signal_path = self.nxroot.nxname + self.nxpath
             else:
-                label = self.nxpath
-            data.nxsignal.attrs['label'] = label
+                signal_path = self.nxpath
+            data.nxsignal.attrs['signal_path'] = signal_path
             plotview.plot(data, fmt, xmin, xmax, ymin, ymax, zmin, zmax, **opts)
         else:
             raise NeXusError("NXfield not plottable")

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -1075,8 +1075,9 @@ class NXattr(object):
         return text(self.nxdata)
 
     def __repr__(self):
-        if (self.dtype is not None and
-                self.dtype.type == np.string_ or self.dtype == string_dtype):
+        if (self.dtype is not None and self.shape != () and
+            (self.dtype.type == np.string_ or self.dtype.type == np.str_ or 
+             self.dtype == string_dtype)):
             return "NXattr('%s')" % self
         else:
             return "NXattr(%s)" % self
@@ -1101,7 +1102,15 @@ class NXattr(object):
         Returns the attribute value.
         """
         try:
-            return self._value[()]
+            if (self.dtype is not None and
+                (self.dtype.type == np.string_ or self.dtype.type == np.str_ or 
+                 self.dtype == string_dtype)):
+                if self.shape == ():
+                    return text(self._value)
+                else:
+                    return [text(value) for value in self._value[()]]
+            else:
+                return self._value[()]
         except TypeError:
             return self._value
 

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -2914,8 +2914,11 @@ class NXfield(NXobject):
 
         if self.is_plottable():
             data = NXdata(self, self.nxaxes, title=self.nxtitle)
+            if self.nxroot.nxclass == "NXroot":
+                label = self.nxroot.nxname + self.nxpath
             else:
-                data = NXdata(self, title=self.nxtitle)
+                label = self.nxpath
+            data.nxsignal.attrs['label'] = label
             plotview.plot(data, fmt, xmin, xmax, ymin, ymax, zmin, zmax, **opts)
         else:
             raise NeXusError("NXfield not plottable")


### PR DESCRIPTION
* Updates the list of NeXus base classes. 
* Improves the `nxaxes` property for NXfields that are not default signals. It now returns the same as the group's default axes if the dimensions are compatible. Multiple signals within a group will now be over-plotted on the same axes.
* Allows NXlinks to be used as signals and axes when creating an NXdata group.
* Adds the `uncertainties` attribute to signals if an error field is specified when creating an NXdata group.
* Automatically converts NXentry groups to a class of NXsubentry when they are assigned to other groups. NXentry groups should only be at the top level of a NeXus file.
* Adds `nxversion`, set to the API version number, to the attributes imported by default.
* Fixes a bug with the file paths of external links embedded in another external link. 
* Fixes a bug when saving external links with absolute file paths.
* Makes the `maxshape` attribute compatible with scalar fields.
* Improves consistency of storing fixed-length string arrays as attributes.