### PR TITLE
Fix attribute bugs

### DIFF
--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -480,9 +480,14 @@ class NXFile(object):
             _target, _filename = _link.path, _link.filename
             _abspath = os.path.isabs(_filename)
         elif 'target' in self.attrs:
-            _target = text(self.attrs['target'])
+            _target = self.attrs['target']
+            if is_iterable(_target):
+                _target = _target[0]
+            _target = text(_target)
             if  _target == self.nxpath:
                 _target = None
+            elif _target is not None:
+                _target = text(_target)
         return _target, _filename, _abspath
 
     def _readchildren(self):

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -5078,9 +5078,9 @@ class NXlog(NXgroup):
         'opts' dictionary.
         """
         title = NXfield("%s Log" % self.nxname)
-        if 'start' in self.time.attrs:
-            title = title + ' - starting at ' + self.time.attrs['start']
-        NXdata(self.value, self.time, title=title).plot(**opts)
+        if 'start' in self['time'].attrs:
+            title = title + ' - starting at ' + self['time'].attrs['start']
+        NXdata(self['value'], self['time'], title=title).plot(**opts)
 
 
 class NXprocess(NXgroup):

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -477,7 +477,6 @@ class NXFile(object):
             _target = self.attrs['target']
             if is_iterable(_target):
                 _target = _target[0]
-            _target = text(_target)
             if  _target == self.nxpath:
                 _target = None
             elif _target is not None:
@@ -4840,6 +4839,9 @@ class NXdata(NXgroup):
         # Check there is a plottable signal
         if self.nxsignal is None:
             raise NeXusError("No plotting signal defined")
+        elif (self.nxaxes is not None and 
+              not self.nxsignal.valid_axes(self.nxaxes)):
+            raise NeXusError("Defined axes not compatible with the signal")
         elif not self.nxsignal.exists():
             raise NeXusError("'%s' does not exist" % 
                              os.path.abspath(self.nxfilename))

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -2839,8 +2839,7 @@ class NXfield(NXobject):
         elif self._memfile:
             raise NeXusError(
             "Cannot change the chunk sizes of a field already in core memory")
-        elif (isinstance(value, (tuple, list, np.ndarray)) and 
-              len(value) != self.ndim):
+        elif is_iterable(value) and len(value) != self.ndim:
             raise NeXusError(
                 "Number of chunks does not match the no. of array dimensions")
         self._chunks = tuple(value)
@@ -4430,7 +4429,7 @@ class NXdata(NXgroup):
         NXgroup.__init__(self, *items, **opts)
         attrs = {}
         if axes is not None:
-            if not isinstance(axes, tuple) and not isinstance(axes, list):
+            if not is_iterable(axes):
                 axes = [axes]
             axis_names = {}
             i = 0
@@ -4704,7 +4703,7 @@ class NXdata(NXgroup):
         
         This assumes that the data is at least two-dimensional.
         """
-        if not isinstance(axes, list) and not isinstance(axes, tuple):
+        if not is_iterable(axes):
             axes = [axes]
         if len(limits) < len(self.nxsignal.shape):
             raise NeXusError("Too few limits specified")
@@ -4954,7 +4953,7 @@ class NXdata(NXgroup):
         The argument should be a list of valid NXfields, which are added, if 
         necessary to the group. Values of None in the list denote missing axes. 
         """
-        if not isinstance(axes, list) and not isinstance(axes, tuple):
+        if not is_iterable(axes):
             axes = [axes]
         axes_attr = []
         for axis in axes:
@@ -5145,8 +5144,7 @@ def convert_index(idx, axis):
     if is_real_slice(idx) and axis.ndim > 1: 
         raise NeXusError(
             "NXfield must be one-dimensional for floating point slices")
-    elif ((isinstance(idx, tuple) or isinstance(idx, list)) and 
-             len(idx) > axis.ndim):
+    elif is_iterable(idx) and len(idx) > axis.ndim:
         raise NeXusError("Slice dimension incompatible with NXfield")
     if len(axis) == 1:
         idx = 0

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -943,17 +943,20 @@ def _getshape(shape):
         return None
     else:
         try:
-            if not isinstance(shape, (list, tuple, np.ndarray)):
+            if not is_iterable(shape):
                 shape = [shape]
-            return tuple([int(i) for i in shape])
+            if None in shape:
+                return None
+            else:
+                return tuple([int(i) for i in shape])
         except ValueError:
             raise NeXusError("Invalid shape: %s" % str(shape))
 
     
 def _getmaxshape(maxshape, shape):
     maxshape, shape = _getshape(maxshape), _getshape(shape)
-    if shape is None:
-        raise NeXusError("Define shape before setting maximum shape")
+    if maxshape is None or shape is None:
+        return None
     else:
         if maxshape == (1,) and shape == ():
             maxshape = ()

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -465,14 +465,13 @@ class NXFile(object):
         else:
             return {}
 
-    def _readnxclass(self, attrs):
-        nxclass = attrs.get('NX_class', None)
-        if isinstance(nxclass, np.ndarray):
+    def _readclass(self, nxclass):
+        if is_iterable(nxclass):
             nxclass = nxclass[0]
-        if nxclass is not None:
-            return text(nxclass)
+        if nxclass is None:
+            return 'NXgroup'
         else:
-            return None
+            return text(nxclass)
 
     def _readlink(self):
         _target, _filename, _abspath = None, None, False
@@ -503,13 +502,9 @@ class NXFile(object):
         Reads the group with the current path and returns it as an NXgroup.
         """
         attrs = self._readattrs()
-        nxclass = self._readnxclass(attrs)
-        if nxclass is not None:
-            del attrs['NX_class']
-        elif self.nxpath == '/':
+        nxclass = self._readclass(attrs.pop('NX_class', 'NXgroup'))
+        if nxclass == 'NXgroup' and self.nxpath == '/':
             nxclass = 'NXroot'
-        else:
-            nxclass = 'NXgroup'
         children = self._readchildren()
         _target, _filename, _abspath = self._readlink()
         if self.nxpath != '/' and _target is not None:

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -1614,8 +1614,8 @@ class NXfield(NXobject):
     This is a subclass of NXobject that contains scalar, array, or string data
     and associated NeXus attributes.
 
-    **Input Parameters**
-
+    Parameters
+    ----------
     value : scalar value, Numpy array, or string
         The numerical or string value of the NXfield, which is directly
         accessible as the NXfield attribute 'nxdata'.
@@ -1649,10 +1649,11 @@ class NXfield(NXobject):
         using the convention for unix file paths.
     group : NXgroup or subclass of NXgroup
         The parent NeXus object. If the NXfield is initialized as the attribute
-        of a parent group, this attribute is automatically set to the parent group.
+        of a parent group, this attribute is automatically set to the parent 
+        group.
 
-    **Python Attributes**
-
+    Attributes
+    ----------
     nxclass : 'NXfield'
         The class of the NXobject.
     nxname : string
@@ -1814,30 +1815,8 @@ class NXfield(NXobject):
     >>> np.sqrt(x)
     array([ 1.        ,  1.41421356,  1.73205081,  2.        ])
 
-    **Methods**
-
-    dir(self, attrs=False):
-        Print the NXfield specification.
-
-        This outputs the name, dimensions and data type of the NXfield.
-        If 'attrs' is True, NXfield attributes are displayed.
-
-    tree:
-        Returns the NXfield's tree.
-
-        It invokes the 'dir' method with both 'attrs' and 'recursive'
-        set to True. Note that this is defined as a property attribute and
-        does not require parentheses.
-
-
-    save(self, filename, format='w5')
-        Save the NXfield into a file wrapped in a NXroot group and NXentry group
-        with default names. This is equivalent to
-
-        >>> NXroot(NXentry(NXfield(...))).save(filename)
-
-    **Examples**
-
+    Examples
+    --------
     >>> x = NXfield(np.linspace(0,2*np.pi,101), units='degree')
     >>> phi = x.nxdata_as(units='radian')
     >>> y = NXfield(np.sin(phi))
@@ -3063,7 +3042,8 @@ class NXgroup(NXobject):
     entries : dictionary
         A dictionary of all the NeXus objects contained within an NXgroup.
     attrs : dictionary
-        A dictionary of all the NeXus attributes, i.e., attribute with class NXattr.
+        A dictionary of all the NeXus attributes, i.e., attribute with class 
+        NXattr.
     entries : dictionary
         A dictionary of all the NeXus objects contained within the group.
     attrs : dictionary
@@ -5051,7 +5031,7 @@ class NXmonitor(NXdata):
     See the NXdata and NXgroup documentation for more details.
     """
 
-    def __init__(self, signal=None, axes=(), *items, **opts):
+    def __init__(self, signal=None, axes=None, *items, **opts):
         NXdata.__init__(self, signal=signal, axes=axes, *items, **opts)
         self._class = "NXmonitor"
         if "name" not in opts:

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -302,6 +302,18 @@ def is_text(value):
         return False
 
 
+def is_iterable(obj):
+    """Return true if the argument is iterable excluding strings."""
+    if is_text(obj):
+        return False
+    else:
+        try:
+            iter(obj)
+        except TypeError:
+            return False
+        return True
+
+
 def natural_sort(key):
     """Sort numbers according to their value, not their first character"""
     return [int(t) if t.isdigit() else t for t in re.split(r'(\d+)', key)]    


### PR DESCRIPTION
* Adds the `nxvalue` property to both NeXus attributes and fields, *i.e.*, NXattr and NXfield objects. Whereas the `nxdata` property contains the value in the original form that is stored in the NeXus file, the `nxvalue` property converts all byte strings to (unicode) strings, string arrays to lists of strings, and size-1 arrays to scalars. This allows Python scripts to utilize the stored values consistently, without being affected by low-level details of how they are stored in the HDF5 files.
* Fixes a bug reading NeXus attributes containing byte string arrays.  
* Fixes a bug where empty 'NX_class' attributes are added when reading groups with no NeXus class specified.
* Fixes a bug when the target attribute of a linked object is stored as a byte string.
