### PR TITLE
Fix is_iterable function

### DIFF
--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -303,15 +303,8 @@ def is_text(value):
 
 
 def is_iterable(obj):
-    """Return true if the argument is iterable excluding strings and fields."""
-    if is_text(obj) or isinstance(obj, NXfield):
-        return False
-    else:
-        try:
-            iter(obj)
-        except TypeError:
-            return False
-        return True
+    """Return true if the argument is a tuple or list."""
+    return isinstance(obj, list) or isinstance(obj, tuple)
 
 
 def natural_sort(key):


### PR DESCRIPTION
It was defined too broadly before, allowing Numpy arrays. This caused an exception when initializing an NXdata group with axes defined as a single Numpy array. This just needs to be a check for tuples or lists.