### PR TITLE
Remove NX_class attribute if it contains 'SDS'

### DIFF
--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -702,6 +702,8 @@ class NXFile(object):
             value = None
         if attrs is None:
             attrs = self.attrs
+            if 'NX_class' in attrs and text(attrs['NX_class']) == 'SDS':
+                attrs.pop('NX_class')
         return value, shape, dtype, attrs
 
     def readvalue(self, path, idx=()):


### PR DESCRIPTION
This removes the NX_class attribute from the NXfield attributes. The is set by the NeXus C-API to 'SDS', but it is redundant in the Python API.  Unless it is explicitly deleted, it will remain in the NeXus file so it has no effect on other programs using the file, but it will be hidden from the Python shell.