### PR TITLE
Use plot_axes function within valid_axes function

### DIFF
--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -4966,9 +4966,10 @@ class NXdata(NXgroup):
             raise NeXusError("Data for '%s' does not exist" % signal.nxpath)
         elif not signal.is_plottable():
             raise NeXusError("'%s' is not plottable" % signal.nxpath)
-        elif (self.nxaxes is not None and 
-              not self.nxsignal.valid_axes(self.nxaxes)):
-            raise NeXusError("Defined axes not compatible with the signal")
+        else:
+            axes = self.plot_axes
+            if axes is not None and not self.nxsignal.valid_axes(axes):
+                raise NeXusError("Defined axes not compatible with the signal")
 
         # Plot with the available plotter
         try:


### PR DESCRIPTION
Some Mantid algorithms produce multidimensional NXdata groups with signals containing size-1 dimensions, whose corresponding axes have size-2 dimensions, i.e, defining a histogram with a single bin. This fix strips the size-1 signal dimensions before calling the `valid_axes` function, so that the size-2 axes are not included in the validation.