### PR TITLE
Add IndexError to the nxaxes exception handler

### DIFF
--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -5091,7 +5091,7 @@ class NXdata(NXgroup):
                 else:
                     axes[i] = plot_axis(self[axis_name])
             return axes
-        except (KeyError, AttributeError, UnboundLocalError):
+        except (AttributeError, IndexError, KeyError, UnboundLocalError):
             axes = {}
             for entry in self:
                 if 'axis' in self[entry].attrs:


### PR DESCRIPTION
If the `axes` attribute exists, but has the wrong shape, this will trigger an IndexError. In principle, this should be raised, but there are so many non-standard NeXus files and customizing exceptions for each one is a major job. Instead, this will enable fallback mechanisms for plotting data without properly defined axes.