### PR TITLE
Add duplicate file script

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,8 @@ setup (name =  nexusformat.__package_name__, # NeXpy
        packages = find_packages('src'),
        entry_points={
             # create & install scripts in <python>/bin
-            'console_scripts': ['nxstack=nexusformat.scripts.nxstack:main'],
+            'console_scripts': ['nxstack=nexusformat.scripts.nxstack:main',
+                                'nxduplicate=nexusformat.scripts.nxduplicate:main'],
        },
        classifiers= ['Development Status :: 4 - Beta',
                      'Intended Audience :: Developers',

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -369,7 +369,7 @@ class NXFile(object):
         elif not os.path.exists(os.path.dirname(name)):
             raise NeXusError("'%s/' does not exist"
                              % os.path.dirname(name))
-        elif mode == 'w' or mode == 'w-' or mode == 'w5' or mode == 'a':
+        elif mode == 'w' or mode == 'w-' or mode == 'w5' or mode == 'a' or mode == 'x':
             if mode == 'w5':
                 mode = 'w'
             self._file = self.h5.File(name, mode, **opts)
@@ -752,9 +752,9 @@ class NXFile(object):
     def writevalue(self, path, value, idx=()):
         self[path][idx] = value
 
-    def copyfile(self, input_file):
+    def copyfile(self, input_file, **opts):
         for entry in input_file['/']:
-            input_file.copy(entry, self['/']) 
+            input_file.copy(entry, self['/'], **opts) 
         self._rootattrs()
 
     def _rootattrs(self):
@@ -5439,10 +5439,10 @@ def save(filename, group, mode='w'):
  
 nxsave = save
 
-def duplicate(input_file, output_file):
+def duplicate(input_file, output_file, mode='w-', **opts):
     input = nxload(input_file)
-    output = NXFile(output_file, 'w')
-    output.copyfile(input.nxfile)
+    output = NXFile(output_file, mode)
+    output.copyfile(input.nxfile, **opts)
 
 nxduplicate = duplicate
 

--- a/src/nexusformat/scripts/nxduplicate.py
+++ b/src/nexusformat/scripts/nxduplicate.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+#-----------------------------------------------------------------------------
+# Copyright (c) 2019, NeXpy Development Team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file COPYING, distributed with this software.
+#-----------------------------------------------------------------------------
+from __future__ import (division, print_function)
+
+import argparse
+from nexusformat.nexus import *
+from nexusformat import __version__
+
+def main():
+
+    parser = argparse.ArgumentParser(
+        description="Copy a NeXus file to another file")
+    parser.add_argument('input', action='store', help="name of NeXus input file")
+    parser.add_argument('output', action='store', help="name of NeXus output file")
+    parser.add_argument('-e', '--expand_external',action='store_true',
+                        help="store external links within the new file")
+    parser.add_argument('-o', '--overwrite',action='store_true',
+                        help="overwrite any existing file")
+    parser.add_argument('-v', '--version', action='version', 
+                        version='nxduplicate v%s' % __version__)
+
+    args = parser.parse_args()
+
+    if args.overwrite:
+        mode = 'w'
+    else:
+        mode = 'w-'
+    nxduplicate(args.input, args.output, mode=mode, expand_external=args.expand_external)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
* Adds `nxduplicate` to the installed scripts.
* Allows externally linked objects to be included in the output file using the h5py `expand_external` copy option.