### PR TITLE
Miscellaneous fixes

### DIFF
--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -3447,7 +3447,8 @@ class NXgroup(NXobject):
                 if isinstance(value, NXfield):
                     group.entries[key]._setattrs(value.attrs)
             elif isinstance(value, NXobject):
-                value = deepcopy(value)
+                if value._group:
+                    value = deepcopy(value)
                 value._group = group
                 value._name = key
                 group.entries[key] = value

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -1892,7 +1892,7 @@ class NXfield(NXobject):
         _h5opts['fletcher32'] = kwds.pop('fletcher32', None)
         _h5opts['maxshape'] = _getmaxshape(kwds.pop('maxshape', None), self._shape)
         _h5opts['scaleoffset'] = kwds.pop('scaleoffset', None)
-        _h5opts['shuffle'] = kwds.pop('shuffle', None)
+        _h5opts['shuffle'] = kwds.pop('shuffle', True if _size>10000 else None)
         self._h5opts = dict((k, v) for (k, v) in _h5opts.items() if v is not None)
         attrs.update(kwds)
         self._attrs = AttrDict(self, attrs=attrs)

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -245,6 +245,7 @@ import re
 import sys
 
 import numpy as np
+import tables
 import h5py as h5
 
 from .. import __version__ as nxversion
@@ -2244,9 +2245,9 @@ class NXfield(NXobject):
         """
         Returns the length of the NXfield data.
         """
-        if self.shape:
-            return int(np.prod(self.shape))
-        else:
+        try:
+            return self.shape[0]
+        except Exception:
             return 0
 
     def __nonzero__(self):

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -280,6 +280,8 @@ nxclasses = ['NXroot', 'NXentry', 'NXsubentry', 'NXdata', 'NXmonitor', 'NXlog',
              'NXtransformations', 'NXtranslation', 'NXuser', 
              'NXvelocity_selector', 'NXxraylens']
 
+if six.PY3:
+    unicode = str
 
 def text(value):
     """Return a unicode string in both Python 2 and 3"""


### PR DESCRIPTION
* Makes the `len` function return the size of the first dimension of NXfields, not the total size. This is compatible with the behavior of Numpy and h5py.
* Provides support for additional h5py options: `compression_opts`, `shuffle`, and `fletcher32`.
* Enables the use of the h5py shuffle filter for large arrays by default, when a suitable compression filter is used. 
* Improves the efficiency of extracting slabs from data copied from NeXus files.