### PR TITLE
Improve field options

### DIFF
--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -2757,7 +2757,6 @@ class NXfield(NXobject):
                         self._value = self._get_uncopied_data()
                     if self._memfile:
                         self._value = self._get_memdata()
-                        self._memfile = None
                 except Exception:
                     raise NeXusError("Cannot read data for '%s'" % self.nxname)
                 if self._value is not None:
@@ -2785,6 +2784,8 @@ class NXfield(NXobject):
         else:
             self._value, self._dtype, self._shape = _getvalue(
                 value, self._dtype, self._shape)
+            if self._memfile:
+                self._put_memdata(self._value)
             self.update()
 
     @property
@@ -2846,8 +2847,6 @@ class NXfield(NXobject):
             else:
                 self._value = np.ma.array(self._value, mask=value)
 
-    @property
-    def dtype(self):
         return self._dtype
 
     @dtype.setter

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -1899,15 +1899,15 @@ class NXfield(NXobject):
         self._value, self._dtype, self._shape = _getvalue(value, dtype, shape)
         _size = _getsize(self._shape)
         _h5opts = {}
-        _h5opts['chunks'] = kwds.pop('chunks', True if _size>10000 else None)
+        _h5opts['chunks'] = kwds.pop('chunks', True if _size>NX_MAXSIZE else None)
         _h5opts['compression'] = kwds.pop('compression', 
-                                          NX_COMPRESSION if _size>10000 else None)
+                                          NX_COMPRESSION if _size>NX_MAXSIZE else None)
         _h5opts['compression_opts'] = kwds.pop('compression_opts', None)
         _h5opts['fillvalue'] = kwds.pop('fillvalue', None)
         _h5opts['fletcher32'] = kwds.pop('fletcher32', None)
         _h5opts['maxshape'] = _getmaxshape(kwds.pop('maxshape', None), self._shape)
         _h5opts['scaleoffset'] = kwds.pop('scaleoffset', None)
-        _h5opts['shuffle'] = kwds.pop('shuffle', True if _size>10000 else None)
+        _h5opts['shuffle'] = kwds.pop('shuffle', True if _size>NX_MAXSIZE else None)
         self._h5opts = dict((k, v) for (k, v) in _h5opts.items() if v is not None)
         attrs.update(kwds)
         self._attrs = AttrDict(self, attrs=attrs)

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -3536,7 +3536,9 @@ class NXgroup(NXobject):
         """
         Implements 'k in d' test using the group's entries.
         """
-        if isinstance(key, NXobject):
+        if isinstance(self, NXroot) and key == '/':
+            return True
+        elif isinstance(key, NXobject):
             return id(key) in [id(x) for x in self.entries.values()]
         else:
             try:

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -2026,9 +2026,9 @@ class NXfield(NXobject):
             if self._value is not None:
                 self._value[idx] = value
             if self.nxfilemode == 'rw':
-                self._put_filedata(idx, value)
+                self._put_filedata(value, idx)
             elif self._value is None:
-                self._put_memdata(idx, value)
+                self._put_memdata(value, idx)
         self.set_changed()
 
     def _str_name(self, indent=0):
@@ -2069,7 +2069,7 @@ class NXfield(NXobject):
                     pass
         return result
 
-    def _put_filedata(self, idx, value):
+    def _put_filedata(self, value, idx=()):
         with self.nxfile as f:
             if isinstance(value, np.ma.MaskedArray):
                 if self.mask is None:
@@ -2087,7 +2087,7 @@ class NXfield(NXobject):
                 result = np.ma.array(result, mask=mask)
         return result
     
-    def _put_memdata(self, idx, value):
+    def _put_memdata(self, value, idx=()):
         if self._memfile is None:
             self._create_memfile()
         if 'data' not in self._memfile:

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -1892,7 +1892,7 @@ class NXfield(NXobject):
     properties = ['mask', 'dtype', 'shape', 'chunks', 'compression', 'compression_opts',
                   'fillvalue', 'fletcher32', 'maxshape', 'scaleoffset', 'shuffle']
 
-    def __init__(self, value=None, name='unknown', dtype=None, shape=None, 
+    def __init__(self, value=None, name='unknown', shape=None, dtype=None, 
                  group=None, attrs={}, **kwds):
         self._class = 'NXfield'
         self._name = name

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -1983,7 +1983,7 @@ class NXfield(NXobject):
         decreasing) one-dimensional arrays.
         """
         idx = convert_index(idx, self)
-        if len(self) == 1:
+        if self.size == 1:
             result = self.nxvalue
         elif self._value is None:
             if self._uncopied_data:
@@ -5310,7 +5310,7 @@ def convert_index(idx, axis):
             "NXfield must be one-dimensional for floating point slices")
     elif is_iterable(idx) and len(idx) > axis.ndim:
         raise NeXusError("Slice dimension incompatible with NXfield")
-    if len(axis) == 1:
+    if axis.size == 1:
         idx = 0
     elif isinstance(idx, slice) and not is_real_slice(idx):
         if idx.start is not None and idx.stop is not None:

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -936,6 +936,21 @@ def _getvalue(value, dtype=None, shape=None):
 
 
 def _getdtype(dtype):
+    """Return a valid h5py dtype.
+
+    This converts string dtypes to the special HDF5 dtype for variable length 
+    strings. Other values are checked against valid Numpy dtypes.
+    
+    Parameters
+    ----------
+    dtype : dtype
+        Proposed datatype of an NXfield.
+    
+    Returns
+    -------
+    dtype
+        Valid dtype for storing in an HDF5 file.
+    """
     if dtype is None:
         return None
     elif is_text(dtype) and dtype == 'char':
@@ -952,6 +967,24 @@ def _getdtype(dtype):
 
 
 def _getshape(shape, maxshape=False):
+    """Return valid shape tuple.
+
+    The returned shape tuple will contain integer values, unless maxshape is
+    True, in which case, values of None are allowed.
+    
+    Parameters
+    ----------
+    shape : tuple of int
+        Proposed new shape
+    maxshape : bool, optional
+        True if values of None are permitted in a shape element,
+        by default False
+    
+    Returns
+    -------
+    tuple of int
+        Valid shape tuple.
+    """
     if shape is None:
         return None
     else:
@@ -969,6 +1002,24 @@ def _getshape(shape, maxshape=False):
 
     
 def _getmaxshape(maxshape, shape):
+    """Return maximum shape if compatible with the specified shape.
+
+    This raises a NeXusError if the length of the shapes do not match or if
+    any of the elements in maxshape are smaller than the corresponding 
+    element in shape. If maxshape has a size of 1, an empty tuple is returned.
+    
+    Parameters
+    ----------
+    maxshape : tuple of int
+        Proposed maximum shape of the array
+    shape : tuple of int
+        Current shape of the array
+    
+    Returns
+    -------
+    tuple of int
+        Maximum shape
+    """
     maxshape, shape = _getshape(maxshape, maxshape=True), _getshape(shape)
     if maxshape is None or shape is None:
         return None
@@ -986,6 +1037,24 @@ def _getmaxshape(maxshape, shape):
 
 
 def _checkshape(shape, maxshape):
+    """Return True if the shape is consistent with the maximum allowed shape.
+
+    Each element of shape must be less than or equal to the 
+    corresponding element of maxshape, unless the latter is set to None, in 
+    which case the value of the shape element is unlimited.
+    
+    Parameters
+    ----------
+    shape : tuple of int
+        Shape to be checked.
+    maxshape : tuple of int
+        Maximum allowed shape
+    
+    Returns
+    -------
+    bool
+        True if the shape is consistent.
+    """
     for i, j in [(_i, _j) for _i, _j in zip(maxshape, shape)]:
         if i is not None and i < j:
             return False
@@ -993,6 +1062,20 @@ def _checkshape(shape, maxshape):
 
     
 def _getsize(shape):
+    """Return the total size of the array with the specified shape.
+
+    If the shape is None, a size of 1 is returned.
+    
+    Parameters
+    ----------
+    shape : tuple of int
+        Shape of the array.
+    
+    Returns
+    -------
+    int
+        Size of the array
+    """
     if shape is None:
         return 1
     else:

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -2031,6 +2031,8 @@ class NXfield(NXobject):
                     "Cannot set a Boolean value to a non-Boolean data type")
             elif value is np.ma.nomask:
                 value = False
+            if isinstance(value, NXfield):
+                value = value.nxdata
             if self._value is not None:
                 self._value[idx] = value
             if self.nxfilemode == 'rw':

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -250,19 +250,18 @@ import h5py as h5
 
 from .. import __version__ as nxversion
 
-#Memory in MB
-NX_MEMORY = 2000
+NX_MEMORY = 2000 #Memory in MB
 NX_COMPRESSION = 'gzip'
 NX_ENCODING = sys.getfilesystemencoding()
+NX_MAXSIZE = 10000
 
 np.set_printoptions(threshold=5)
 string_dtype = h5.special_dtype(vlen=six.text_type)
 
 __all__ = ['NXFile', 'NXobject', 'NXfield', 'NXgroup', 'NXattr', 
            'NXlink', 'NXlinkfield', 'NXlinkgroup', 'NeXusError', 
-           'NX_MEMORY', 'nxgetmemory', 'nxsetmemory', 
-           'NX_COMPRESSION', 'nxgetcompression', 'nxsetcompression',
-           'NX_ENCODING', 'nxgetencoding', 'nxsetencoding',
+           'nxgetmemory', 'nxsetmemory', 'nxgetcompression', 'nxsetcompression',
+           'nxgetencoding', 'nxsetencoding', 'nxgetmaxsize', 'nxsetmaxsize',
            'nxclasses', 'nxload', 'nxsave', 'nxduplicate', 'nxdir', 'nxdemo',
            'nxversion']
 
@@ -5412,6 +5411,24 @@ def setencoding(value):
     NX_ENCODING = value
 
 nxsetencoding = setencoding
+
+def getmaxsize():
+    """
+    Returns the default maximum size for arrays without using core memory.
+    """
+    global NX_MAXSIZE
+    return NX_MAXSIZE
+
+nxgetmaxsize = getmaxsize
+
+def setmaxsize(value):
+    """
+    Sets the default maximum size for arrays without using core memory.
+    """
+    global NX_MAXSIZE
+    NX_MAXSIZE = value
+
+nxsetmaxsize = setmaxsize
 
 # File level operations
 def load(filename, mode='r'):


### PR DESCRIPTION
* Provides support for additional h5py options, such as `shuffle` and `fletcher32`. 
* Allows resizing of NXfields under the constraints set by `maxshape` even if it is not stored in a file.
* Returns `fillvalue` if defined when accessing slabs from NXfields with uninitialized values. Previously, the fill value was only useful when the NXfield had been saved to a file.
* Adds a NX_MAXSIZE global variable, accessible using `nxgetmaxsize` and `nxsetmaxsize`, to set the size at which compression and chunking is turned on by default. 
* Removes NX_MEMORY, NX_ENCODING, and NX_COMPRESSION from global imports. They are not updated in the NeXpy shell when their initial values are changed. Their values are accessible using their respective `nxget...` and `nxset...` functions. 