### PR TITLE
Fix resize

### DIFF
--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -2955,8 +2955,10 @@ class NXfield(NXobject):
             if self.nxfilemode:
                 with self.nxfile as f:
                     f[self.nxpath].shape = shape
+                self._value = None
             elif self._memfile:
                 self._memfile['data'].shape = shape
+                self._value = None
         else:
             raise NeXusError("Shape incompatible with current NXfield")
         self._shape = shape
@@ -3043,7 +3045,7 @@ class NXfield(NXobject):
     @fillvalue.setter
     def fillvalue(self, value):
         self.set_h5opt('fillvalue', value)
-        
+
     @property
     def fletcher32(self):
         return self.get_h5opt('fletcher32')

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -2122,7 +2122,17 @@ class NXfield(NXobject):
             if self.nxfilemode == 'rw':
                 self._put_filedata(value, idx)
             elif self._value is None:
-                self._put_memdata(value, idx)
+                if self.size > NX_MAXSIZE:
+                    self._put_memdata(value, idx)
+                else:
+                    self._value = np.empty(self.shape, self.dtype)
+                    if self.fillvalue:
+                        self._value.fill(self.fillvalue)
+                    elif is_string_dtype(self.dtype):
+                        self._value.fill(' ')
+                    else:
+                        self._value.fill(0)
+                    self._value[idx] = value
         self.set_changed()
 
     def _str_name(self, indent=0):


### PR DESCRIPTION
* Forces cached values to be updated from the NeXus file when an NXfield has been resized.
* Allows slabs to be added to a NXfield without creating a HDF5 core memory file. This only affects a small NXfield (< NX_MAXSIZE), which is not already stored in a NeXus file, and whose value was not initialized when it was created. The field array is initialized with fill values before substituting the slab.