### PR TITLE
Ensure that the HDF5 file is closed when initialized

### DIFF
--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -501,7 +501,7 @@ class NXFile(object):
             self._file.close()
 
     def isopen(self):
-        return self._file.id.valid:
+        return self._file.id.valid
 
     def readfile(self):
         """


### PR DESCRIPTION
* Close the `h5py.File` object when creating the NXFile class. In general, it should only be open when used by a context manager.
* This is in response to #96.