### PR TITLE
Add locks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: python
 python:
   - 3.7
   - 3.6
-  - 3.5
-  - 3.4
 install:
     pip install . -r requirements.txt
 script:

--- a/src/nexusformat/nexus/__init__.py
+++ b/src/nexusformat/nexus/__init__.py
@@ -37,7 +37,7 @@ We can examine the file structure using a number of commands::
 
     f.attrs             # Shows file name, date, user, and NeXus version
     f.tree()            # Lists the entire contents of the NeXus file
-    f.NXentry             # Shows the list of datasets in the file
+    f.NXentry           # Shows the list of datasets in the file
     f.NXentry[0].dir()  # Lists the fields in the first entry
 
 Some files can even be plotted automatically::
@@ -50,25 +50,14 @@ We can create a copy of the file using write::
 
 For a complete description of the features available in this tree view
 of the NeXus data file, see `nexus.tree`.
-
-NeXus API
-=========
-
-When converting code to python from other languages you do not
-necessarily want to rewrite the file handling code using the
-tree view.  The `nexus.napi` module provides an interface which
-more closely follows the NeXus application programming
-interface (NAPI_).
-
-.. _Nexus: http://www.nexusformat.org/Introduction
-.. _NAPI:  http://www.nexusformat.org/Application_Program_Interface
-.. _HDF:   http://www.hdfgroup.org
 """
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-from .tree import *
 from .completer import nxcompleter
+from .lock import NXLock, NXLockException
+from .tree import *
+
 try:
     import h5pyd
     from .remote import *

--- a/src/nexusformat/nexus/lock.py
+++ b/src/nexusformat/nexus/lock.py
@@ -1,0 +1,95 @@
+import os
+import time, timeit
+import errno
+
+
+class NXLockException(Exception):
+    LOCK_FAILED = 1
+
+class NXLock(object):
+
+    def __init__(self, filename, timeout=600, check_interval=1):
+        """Create a lock to prevent file access.
+
+        This creates a lock, which can be later acquired and released. It
+        creates a file, named `<filename>.lock`, which contains the 
+        calling process ID. 
+        
+        Parameters
+        ----------
+        filename : str
+            Name of file to be locked.
+        timeout : int, optional
+            Number of seconds to wait for a prior lock to clear before 
+            raising a NXLockException, by default 600.
+        check_interval : int, optional
+            Number of seconds between attempts to acquire the lock, 
+            by default 1.
+        """
+        self.filename = os.path.realpath(filename)
+        self.lock_file = self.filename+'.lock'
+        self.timeout = timeout
+        self.check_interval = check_interval
+        self.fd = None
+
+    def acquire(self, timeout=None, check_interval=None):
+        """Acquire the lock.
+        
+        Parameters
+        ----------
+        timeout : int, optional
+            Number of seconds to wait for a prior lock to clear before 
+            raising a NXLockException, by default `self.timeout`.
+        check_interval : int, optional
+            Number of seconds between attempts to acquire the lock, 
+            by default `self.check_interval`.
+        
+        Raises
+        ------
+        NXLockException
+            If lock not acquired before `timeout`.
+        """
+        if timeout is None:
+            timeout = self.timeout
+        if timeout is None:
+            timeout = 0
+
+        if check_interval is None:
+            check_interval = self.check_interval
+
+        timeoutend = timeit.default_timer() + timeout
+        while timeoutend > timeit.default_timer():
+            try:
+                # Attempt to create the lockfile. If it already exists,
+                # then someone else has the lock and we need to wait
+                self.fd = os.open(self.lock_file,
+                        os.O_CREAT | os.O_EXCL | os.O_RDWR)
+                open(self.lock_file, 'w').write(str(os.getpid()))
+                break
+            except OSError as e:
+                # Only catch if the lockfile already exists
+                if e.errno != errno.EEXIST:
+                    raise
+                time.sleep(check_interval)
+        # Raise on error if we had to wait for too long
+        else:
+            raise NXLockException("'%s' timeout expired" % self.filename)
+
+    def release(self):
+        """Release the lock."""
+        if self.fd is not None:
+            os.close(self.fd)
+            try:
+                os.remove(self.lock_file)
+            except FileNotFoundError:
+                pass
+            self.fd = None
+
+    def __enter__(self):
+        return self.acquire()
+
+    def __exit__(self, type_, value, tb):
+        self.release()
+
+    def __del__(self):
+        self.release()

--- a/src/nexusformat/nexus/lock.py
+++ b/src/nexusformat/nexus/lock.py
@@ -110,8 +110,7 @@ class NXLock(object):
             except FileNotFoundError:
                 pass
             self.fd = None
-            print('Unlocked ' + str(self.pid) + ' ' + format_timestamp(timestamp()))
-
+ 
     @property
     def locked(self):
         """Return True if the current process has locked the file."""
@@ -136,7 +135,7 @@ class NXLock(object):
                 os.remove(self.lock_file)
             except FileNotFoundError:
                 pass
- 
+
     def wait(self, timeout=None, check_interval=None):
         """Wait until an existing lock is cleared.
         

--- a/src/nexusformat/nexus/lock.py
+++ b/src/nexusformat/nexus/lock.py
@@ -1,10 +1,17 @@
-import os
-import time, timeit
 import errno
+import os
+import time
+import timeit
+
+import six
+
+if six.PY2:
+    FileNotFoundError = IOError
 
 
 class NXLockException(Exception):
     LOCK_FAILED = 1
+
 
 class NXLock(object):
 

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -282,7 +282,9 @@ nxclasses = ['NXroot', 'NXentry', 'NXsubentry', 'NXdata', 'NXmonitor', 'NXlog',
              'NXtransformations', 'NXtranslation', 'NXuser', 
              'NXvelocity_selector', 'NXxraylens']
 
-if six.PY3:
+if six.PY2:
+    FileNotFoundError = IOError
+else:
     unicode = str
 
 

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -5593,10 +5593,7 @@ def getmemory():
     """
     Returns the memory limit for data arrays (in MB).
     """
-    global NX_MEMORY
     return NX_MEMORY
-
-nxgetmemory = getmemory
 
 def setmemory(value):
     """
@@ -5605,16 +5602,14 @@ def setmemory(value):
     global NX_MEMORY
     NX_MEMORY = value
 
+nxgetmemory = getmemory
 nxsetmemory = setmemory
 
 def getcompression():
     """
     Returns default compression filter.
     """
-    global NX_COMPRESSION
     return NX_COMPRESSION
-
-nxgetcompression = getcompression
 
 def setcompression(value):
     """
@@ -5625,16 +5620,14 @@ def setcompression(value):
         value = None
     NX_COMPRESSION = value
 
+nxgetcompression = getcompression
 nxsetcompression = setcompression
 
 def getencoding():
     """
     Returns the default encoding for input strings (usually 'utf-8').
     """
-    global NX_ENCODING
     return NX_ENCODING
-
-nxgetencoding = getencoding
 
 def setencoding(value):
     """
@@ -5643,16 +5636,14 @@ def setencoding(value):
     global NX_ENCODING
     NX_ENCODING = value
 
+nxgetencoding = getencoding
 nxsetencoding = setencoding
 
 def getmaxsize():
     """
     Returns the default maximum size for arrays without using core memory.
     """
-    global NX_MAXSIZE
     return NX_MAXSIZE
-
-nxgetmaxsize = getmaxsize
 
 def setmaxsize(value):
     """
@@ -5661,6 +5652,7 @@ def setmaxsize(value):
     global NX_MAXSIZE
     NX_MAXSIZE = value
 
+nxgetmaxsize = getmaxsize
 nxsetmaxsize = setmaxsize
 
 # File level operations

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -5685,9 +5685,8 @@ def save(filename, group, mode='w'):
 nxsave = save
 
 def duplicate(input_file, output_file, mode='w-', **kwargs):
-    input = nxload(input_file)
-    output = NXFile(output_file, mode)
-    output.copyfile(input.nxfile, **kwargs)
+    with NXFile(input_file, 'r') as input, NXFile(output_file, mode) as output:
+        output.copyfile(input, **kwargs)
 
 nxduplicate = duplicate
 

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -5599,9 +5599,28 @@ def centers(signal, axes):
     return [findc(a,signal.shape[i]) for i,a in enumerate(axes)]
 
 def getlock():
+    """Return the number of seconds before a lock acquisition times out.
+
+    If the value is 0, file locking is disabled.
+    
+    Returns
+    -------
+    int
+        Number of seconds before a lock acquisition times out.
+    """
     return NX_LOCK
     
-def setlock(value):
+def setlock(value=60):
+    """Initialize NeXus file locking.
+
+    This creates a file with `.lock` appended to the NeXus file name.
+    
+    Parameters
+    ----------
+    value : int, optional
+        Number of seconds before a lock acquisition times out, by default 60.
+        If the value is set to 0, file locking is disabled.
+    """
     global NX_LOCK
     NX_LOCK = value
 

--- a/tests/test_locks.py
+++ b/tests/test_locks.py
@@ -1,0 +1,65 @@
+import os
+import pytest
+from nexusformat.nexus import *
+
+
+field1 = NXfield('a', name="f1")
+
+
+def test_lock_creation(tmpdir):
+
+    filename = os.path.join(tmpdir, 'file1.nxs')
+    root = NXroot(NXentry(field1))
+    root.save(filename)
+
+    assert root.nxfile.lock is None
+
+    root.nxfile.lock = 20
+    root.nxfile.acquire_lock()
+    root.nxfile.release_lock()
+
+    assert not root.nxfile.locked
+    assert not root.nxfile.is_locked()
+
+    root.nxfile.lock = True
+    root.nxfile.acquire_lock()
+
+    assert root.nxfile.locked
+    assert root.nxfile.is_locked()
+    assert root.nxfile.lock.timeout == 10
+
+    root['entry/f1'] = 'b'
+
+    assert root['entry/f1'] == 'b'
+    
+    assert not root.nxfile.locked
+    assert not root.nxfile.is_locked()
+
+
+def test_locked_assignments(tmpdir):
+
+    filename = os.path.join(tmpdir, 'file1.nxs')
+    root = NXroot(NXentry(field1))
+    root.save(filename)
+    assert root.nxfile.lock is None
+
+    original_id = id(root.nxfile)
+    original_mtime = root._mtime
+
+    root['entry/f1'] = 'b'
+
+    assert root['entry/f1'] == 'b'
+    assert root.nxfile.lock is None
+    
+    root.nxfile.lock = 10
+
+    assert isinstance(root.nxfile.lock, NXLock)
+    assert root.nxfile.lock.timeout == 10
+
+    root['entry/f1'] = 'c'
+
+    assert root['entry/f1'] == 'c'
+    assert id(root.nxfile) == original_id
+    assert root._mtime > original_mtime
+
+


### PR DESCRIPTION
* Adds a file-based locking class
* Allows the use of locks to be configured for a NXFile object. They are disabled by default.
* Triggers the use of locks automatically when a lock from another process is detected.
* Allows stale locks to be cleared.