### PR TITLE
Add h5py methods

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: python
 python:
   - 3.7
   - 3.6
-  - 3.5
-  - 3.4
 install:
     pip install . -r requirements.txt
 script:

--- a/setup.py
+++ b/setup.py
@@ -35,8 +35,9 @@ setup (name =  nexusformat.__package_name__, # NeXpy
        packages = find_packages('src'),
        entry_points={
             # create & install scripts in <python>/bin
-            'console_scripts': ['nxstack=nexusformat.scripts.nxstack:main',
-                                'nxduplicate=nexusformat.scripts.nxduplicate:main'],
+            'console_scripts': 
+                ['nxstack=nexusformat.scripts.nxstack:main',                
+                 'nxduplicate=nexusformat.scripts.nxduplicate:main'],
        },
        classifiers= ['Development Status :: 4 - Beta',
                      'Intended Audience :: Developers',

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,6 @@
 from setuptools import setup, find_packages, Extension
 
 import os, sys
-import numpy
 import versioneer
 
 # pull in some definitions from the package's __init__.py file

--- a/setup.py
+++ b/setup.py
@@ -10,8 +10,6 @@
 from setuptools import setup, find_packages, Extension
 
 import os, sys
-import pkg_resources
-pkg_resources.require('numpy')
 import numpy
 import versioneer
 

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -3669,8 +3669,13 @@ class NXgroup(NXobject):
     def __init__(self, *args, **kwargs):
         self._entries = {}
         if "name" in kwargs:
-            self._name = kwargs["name"]
-            del kwargs["name"]
+            self._name = kwargs.pop("name")
+        if "nxclass" in kwargs:
+            self._class = kwargs.pop("nxclass")
+        if "group" in kwargs:
+            self._group = kwargs.pop("group")
+        self._copyfile = kwargs.pop("nxcopy", None)
+        self._copypath = kwargs.pop("nxpath", None)
         if "entries" in kwargs:
             for k,v in kwargs["entries"].items():
                 self._entries[k] = deepcopy(v)
@@ -3684,12 +3689,6 @@ class NXgroup(NXobject):
             del kwargs["attrs"]
         else:
             self._attrs = AttrDict(self)
-        if "nxclass" in kwargs:
-            self._class = kwargs["nxclass"]
-            del kwargs["nxclass"]
-        if "group" in kwargs:
-            self._group = kwargs["group"]
-            del kwargs["group"]
         for k,v in kwargs.items():
             try:
                 self[k] = v

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -483,9 +483,6 @@ class NXFile(object):
     def get(self, *args, **kwargs):
         return self.file.get(*args, **kwargs)
 
-    def copy(self, *args, **kwargs):
-        self.file.copy(*args, **kwargs)
-
     def open(self, **kwargs):
         if not self.isopen():
             if self._mode == 'rw':
@@ -498,6 +495,12 @@ class NXFile(object):
     def close(self):
         if self.isopen():
             self._file.close()
+
+    def move(self, source, destination):
+        self.file.move(source, destination)
+
+    def copy(self, source, destination, **kwargs):
+        self.file.copy(source, destination, **kwargs)
 
     def isopen(self):
         if self._file.id:

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -1845,7 +1845,7 @@ class NXobject(object):
             NeXus object containing information for subsequent copies.
         """
         if self.nxfilemode is None:
-            raise NeXusError("Can only copy from a NeXus file.")
+            raise NeXusError("Can only copy objects saved to a NeXus file.")
         if name is None:
             name = self.nxname
         return NXobject(name=name, nxclass=self.nxclass, 
@@ -3877,6 +3877,9 @@ class NXgroup(NXobject):
                 if isinstance(value, NXfield):
                     group.entries[key]._setattrs(value.attrs)
             elif isinstance(value, NXobject):
+                if group.nxfilemode is None and value._copyfile is not None:
+                    raise NeXusError(
+                        "Can only copy objects to another NeXus file.")
                 if value._group:
                     value = deepcopy(value)
                 value._group = group

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -4518,7 +4518,7 @@ class NXlink(NXobject):
                 self._setclass(NXlinkfield)
             elif isinstance(item, NXgroup):
                 self._setclass(_getclass(item.nxclass, link=True))
-            self.copy(item)
+            self.copylink(item)
         return self._link
 
     @property
@@ -4584,7 +4584,7 @@ class NXlinkfield(NXlink, NXfield):
         else:
             self.nxlink.__setitem__(key, value)
 
-    def copy(self, field):
+    def copylink(self, field):
         self._value = field._value
         self._shape = field._shape
         self._dtype = field._dtype
@@ -4645,7 +4645,7 @@ class NXlinkgroup(NXlink, NXgroup):
         except Exception:
             return NXlink(self)._str_tree(self, indent=indent)
         
-    def copy(self, group):
+    def copylink(self, group):
         self._entries = group._entries
         self._attrs = group._attrs
 

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -845,7 +845,7 @@ class NXFile(object):
                         return []
                 else:
                     self[self.nxparent].create_group(group.nxname)
-            if group.nxclass and group.nxclass != 'unknown':
+            if group.nxclass and group.nxclass != 'NXgroup':
                 self[self.nxpath].attrs['NX_class'] = group.nxclass
         links = []
         self._writeattrs(group.attrs)
@@ -901,7 +901,8 @@ class NXFile(object):
         elif data.dtype is not None:
             if data.nxname not in self[self.nxparent]:
                 self[self.nxparent].create_dataset(data.nxname, 
-                                                   shape=data.shape, dtype=data.dtype,
+                                                   shape=data.shape, 
+                                                   dtype=data.dtype,
                                                    **data._h5opts)
             try:
                 if data._value is not None:

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -4442,12 +4442,13 @@ class NXlink(NXobject):
 
     def __getattr__(self, name):
         if self.is_external():
-            if self.exists():
+            try:
                 with self.nxfile as f:
                     item = f.readpath(self.nxfilepath)
                 return getattr(item, name)
-            else:
-                raise NeXusError("Cannot read the external link to '%s'" % self._filename)
+            except Exception:
+                raise NeXusError("Cannot read the external link to '%s'" 
+                                  % self._filename)
         else:
             if self.nxlink:
                 return getattr(self.nxlink, name)

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -2169,10 +2169,11 @@ class NXfield(NXobject):
     2) Referencing a NeXus attribute
 
        If the name of the NeXus attribute is not the same as any of the Python
-       attributes listed above, or one of the methods listed below, or any of the
-       attributes defined for Numpy arrays, they can be referenced as if they were
-       a Python attribute of the NXfield. However, it is only possible to reference
-       attributes with one of the proscribed names using the 'attrs' dictionary.
+       attributes listed above, or one of the methods listed below, or any of
+       the attributes defined for Numpy arrays, they can be referenced as if
+       they were a Python attribute of the NXfield. However, it is only possible
+       to reference attributes with one of the proscribed names using the
+       'attrs' dictionary.
 
         >>> entry.sample.temperature.tree = 10.0
         >>> entry.sample.temperature.tree
@@ -2275,8 +2276,9 @@ class NXfield(NXobject):
                     value = slab.get([i,j,0],size)
 
     """
-    properties = ['mask', 'dtype', 'shape', 'chunks', 'compression', 'compression_opts',
-                  'fillvalue', 'fletcher32', 'maxshape', 'scaleoffset', 'shuffle']
+    properties = ['mask', 'dtype', 'shape', 'chunks', 'compression', 
+                  'compression_opts', 'fillvalue', 'fletcher32', 'maxshape', 
+                  'scaleoffset', 'shuffle']
 
     def __init__(self, value=None, name='unknown', shape=None, dtype=None, 
                  group=None, attrs={}, **kwargs):
@@ -2286,16 +2288,21 @@ class NXfield(NXobject):
         self._value, self._dtype, self._shape = _getvalue(value, dtype, shape)
         _size = _getsize(self._shape)
         _h5opts = {}
-        _h5opts['chunks'] = kwargs.pop('chunks', True if _size>NX_MAXSIZE else None)
+        _h5opts['chunks'] = kwargs.pop('chunks', 
+                                       True if _size>NX_MAXSIZE else None)
         _h5opts['compression'] = kwargs.pop('compression', 
-                                            NX_COMPRESSION if _size>NX_MAXSIZE else None)
+                                            NX_COMPRESSION 
+                                            if _size>NX_MAXSIZE else None)
         _h5opts['compression_opts'] = kwargs.pop('compression_opts', None)
         _h5opts['fillvalue'] = kwargs.pop('fillvalue', None)
         _h5opts['fletcher32'] = kwargs.pop('fletcher32', None)
-        _h5opts['maxshape'] = _getmaxshape(kwargs.pop('maxshape', None), self._shape)
+        _h5opts['maxshape'] = _getmaxshape(kwargs.pop('maxshape', None), 
+                                           self._shape)
         _h5opts['scaleoffset'] = kwargs.pop('scaleoffset', None)
-        _h5opts['shuffle'] = kwargs.pop('shuffle', True if _size>NX_MAXSIZE else None)
-        self._h5opts = dict((k, v) for (k, v) in _h5opts.items() if v is not None)
+        _h5opts['shuffle'] = kwargs.pop('shuffle', 
+                                        True if _size>NX_MAXSIZE else None)
+        self._h5opts = dict((k, v) for (k, v) in _h5opts.items() 
+                            if v is not None)
         attrs.update(kwargs)
         self._attrs = AttrDict(self, attrs=attrs)
         self._memfile = None

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -793,6 +793,8 @@ class NXFile(object):
                 _target = _link.path
             elif 'target' in self.attrs:
                 _target = text(self.attrs['target'])
+                if not _target.startswith('/'):
+                    _target = '/' + _target
                 if _target == self.nxpath:
                     _target = None
         return _target, _filename, _abspath
@@ -4433,6 +4435,8 @@ class NXlink(NXobject):
             if name is None and is_text(target):
                 self._name = target.rsplit('/', 1)[1]
             self._target = text(target)
+            if not self._target.startswith('/'):
+                self._target = '/' + self._target
         self._link = None
 
     def __repr__(self):

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -496,12 +496,6 @@ class NXFile(object):
         if self.isopen():
             self._file.close()
 
-    def move(self, source, destination):
-        self.file.move(source, destination)
-
-    def copy(self, source, destination, **kwargs):
-        self.file.copy(source, destination, **kwargs)
-
     def isopen(self):
         if self._file.id:
             return True
@@ -726,12 +720,12 @@ class NXFile(object):
             _file, _path = data._uncopied_data
             if _file._filename != self._filename:
                 with _file as f:
-                    f.copy(_path, self[self.nxparent], self.nxpath)
+                    f.copy(_path, self[self.nxparent], name=self.nxpath)
             else:
-                self.file.copy(_path, self[self.nxparent], self.nxpath)
+                self.file.copy(_path, self[self.nxparent], name=self.nxpath)
             data._uncopied_data = None
         elif data._memfile:
-            data._memfile.copy('data', self[self.nxparent], self.nxpath)
+            data._memfile.copy('data', self[self.nxparent], name=self.nxpath)
             data._memfile = None
         elif data.nxfile and data.nxfile.filename != self.filename:
             data.nxfile.copy(data.nxpath, self[self.nxparent])
@@ -812,6 +806,12 @@ class NXFile(object):
 
     def writevalue(self, path, value, idx=()):
         self[path][idx] = value
+
+    def move(self, source, destination):
+        self.file.move(source, destination)
+
+    def copy(self, source, destination, **kwargs):
+        self.file.copy(source, destination, **kwargs)
 
     def copyfile(self, input_file, **kwargs):
         for entry in input_file['/']:
@@ -2344,7 +2344,7 @@ class NXfield(NXobject):
                     f.copy(_path, self.nxpath)
                 else:
                     self._create_memfile()
-                    f.copy(_path, self._memfile, 'data')
+                    f.copy(_path, self._memfile, name='data')
                 self._uncopied_data = None
                 if (np.prod(self.shape) * np.dtype(self.dtype).itemsize 
                     <= NX_MEMORY*1000*1000):

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -439,7 +439,10 @@ class NXFile(object):
         elif mode == 'w' or mode == 'w-' or mode == 'w5' or mode == 'a' or mode == 'x':
             if mode == 'w5':
                 mode = 'w'
-            self._file = self.h5.File(name, mode, **kwargs)
+            try:
+                self._file = self.h5.File(self._filename, mode, **kwargs)
+            except Exception as error:
+                raise NeXusError("'%s' cannot be opened by h5py" % self._filename)
             self._mode = 'rw'
         else:
             if mode == 'rw' or mode == 'r+':
@@ -448,7 +451,10 @@ class NXFile(object):
             else:
                 self._mode = 'r'
             if os.path.exists(name):
-                self._file = self.h5.File(name, mode, **kwargs)
+                try:
+                    self._file = self.h5.File(self._filename, mode, **kwargs)
+                except Exception as error:
+                    raise NeXusError("'%s' cannot be opened by h5py" % self._filename)
             else:
                 raise NeXusError("'%s' does not exist" % name)
         self._filename = self._file.filename                             

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -4052,7 +4052,7 @@ class NXgroup(NXobject):
             elif group in self.nxroot:
                 group = self.nxroot[group]
             else:
-                raise NeXusError("'%s' not in tree")
+                raise NeXusError("'%s' not in tree" % group)
             if not isinstance(group, NXgroup):
                 raise NeXusError("Destination must be a valid NeXus group")
         if item.nxroot != group.nxroot:

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,0 +1,143 @@
+import numpy as np
+import pytest
+from nexusformat.nexus import *
+
+x = NXfield(2 * np.linspace(0.0, 10.0, 11, dtype=np.float64), name="x")
+y = NXfield(3 * np.linspace(0.0, 5.0, 6, dtype=np.float64), name="y")
+z = NXfield(4 * np.linspace(0.0, 2.0, 3, dtype=np.float64), name="z")
+v = NXfield(np.linspace(0, 10*5*2, num=10*5*2, dtype=np.float64), name="v")
+v.resize((2,5,10))
+
+
+def test_data_creation():
+
+    data = NXdata(v, (z, y, x), title="Title")
+    
+    assert "signal" in data.attrs
+    assert "axes" in data.attrs
+    assert len(data.attrs["axes"]) == 3
+    
+    assert data.nxsignal.nxname == "v"
+    assert data.nxsignal.ndim == 3
+    assert data.nxsignal.shape == (2, 5, 10)
+    assert [axis.nxname for axis in data.nxaxes] == ["z", "y", "x"]
+    assert [axis.ndim for axis in data.nxaxes] == [1, 1, 1]
+    assert [axis.shape for axis in data.nxaxes] == [(3,), (6,), (11,)]
+
+    assert data.nxtitle == "Title"
+
+
+def test_plottable_data():
+
+    data = NXdata(v, (z, y, x), title="Title")
+
+    assert data.is_plottable()
+    assert data.plottable_data is data
+    assert data.plot_rank == 3
+    assert data.plot_rank == data.nxsignal.ndim
+    assert data.plot_axes == data.nxaxes
+    assert data.nxsignal.valid_axes(data.nxaxes)
+
+
+def test_signal_selection():
+
+    data = NXdata()
+    data.nxsignal = v
+    data.nxaxes = (z, y, x)
+
+    assert data.nxsignal.nxname == "v"
+    assert [axis.nxname for axis in data.nxaxes] == ["z", "y", "x"]
+
+
+def test_size_one_axis():
+
+    y1 = np.array((1), dtype=np.float64)
+    v1 =  NXfield(np.linspace(0, 10*1*2, num=10*1*2, dtype=np.int64), name="v")
+    v1.resize((2,1,10))
+
+    data = NXdata(v1, (z, y1, x))
+
+    assert data.is_plottable()
+    assert data.plottable_data is data
+    assert data.plot_rank == 2
+    assert data.plot_rank == data.nxsignal.ndim - 1
+    assert len(data.plot_axes) == 2
+    assert data.plot_shape == (2, 10)
+    assert data.nxsignal.valid_axes(data.plot_axes)
+
+
+def test_data_operations():
+
+    data = NXdata(v, (z, y, x))
+    new_data = data + 1
+
+    assert np.array_equal(new_data.nxsignal.nxvalue, v + 1)
+    assert new_data.nxaxes == data.nxaxes
+    assert new_data.nxsignal.nxname == "v"
+    assert [axis.nxname for axis in data.nxaxes] == ["z", "y", "x"]
+
+    new_data = data - 1
+
+    assert np.array_equal(new_data.nxsignal, v - 1)
+
+    new_data = data * 2
+
+    assert np.array_equal(new_data.nxsignal, v * 2)
+
+    new_data = 2 * data
+
+    assert np.array_equal(new_data.nxsignal, v * 2)
+
+    new_data = data / 2
+
+    assert np.array_equal(new_data.nxsignal, v / 2)
+
+    new_data = 2 * data - data
+
+    assert np.array_equal(new_data.nxsignal, v)
+
+
+def test_data_errors():
+
+    y1 = NXfield(np.linspace(1, 10, 10), name="y")
+    v1 = NXfield(y1**2, name="v")
+    e1 = NXfield(np.sqrt(v1), name="e")
+
+    data = NXdata(v1, (y1), errors=e1)
+
+    assert data.nxerrors.nxname == "e"
+    assert np.array_equal(data.nxerrors, e1)
+
+    new_data = 2 * data
+
+    assert np.array_equal(new_data.nxerrors, 2 * e1)
+
+    new_data = 2 * data - data
+
+    assert np.array_equal(new_data.nxerrors, e1 * np.sqrt(5))
+ 
+    new_data = data - data / 2
+
+    assert np.array_equal(new_data.nxerrors, e1 * np.sqrt(1.25))
+   
+
+def test_data_slabs():
+
+    data = NXdata(v, (z, y, x), title="Title")
+ 
+    slab = data[0,:,:]
+
+    assert np.array_equal(slab.nxsignal, v[0])
+    assert slab.plot_rank == 2
+    assert slab.plot_shape == v[0].shape
+    assert slab.nxaxes == [y, x]
+
+    slab = data[0, 3.:12., 2.:18.]
+
+    assert slab.plot_shape == (v.shape[1]-2, v.shape[2]-2)
+    assert slab.plot_axes == [y[1:-1], x[1:-1]]
+
+    slab = data[0, 3.5:11.5, 2.5:17.5]
+
+    assert slab.plot_shape == (v.shape[1]-2, v.shape[2]-2)
+    assert slab.plot_axes == [y[1:-1], x[1:-1]]

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -20,7 +20,7 @@ def test_string_field_creation(text):
     assert field.nxvalue == text
     assert field.dtype == string_dtype
     assert len(field) == 0
- 
+
 
 @pytest.mark.parametrize("text", ["a", "abc", "αβγ"])
 def test_byte_field_creation(text):
@@ -74,6 +74,3 @@ def test_field_index(arr, ind):
 
     assert np.all(field[ind].nxvalue == arr[ind])
     assert field[ind].shape == arr[ind].shape
-
-
-        

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1,10 +1,9 @@
 import h5py as h5
 import numpy as np
 import pytest
-import six
 from nexusformat.nexus import *
 
-string_dtype = h5.special_dtype(vlen=six.text_type)
+string_dtype = h5.special_dtype(vlen=str)
 NX_ENCODING = nxgetencoding()
 
 arr1D = np.linspace(0.0, 100.0, 101, dtype=np.float64)
@@ -72,5 +71,5 @@ def test_field_index(arr, ind):
 
     field = NXfield(arr)
 
-    assert np.all(field[ind].nxvalue == arr[ind])
+    assert np.array_equal(field[ind].nxvalue, arr[ind])
     assert field[ind].shape == arr[ind].shape

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -1,0 +1,41 @@
+import h5py as h5
+import numpy as np
+import os
+import pytest
+import six
+from nexusformat.nexus import *
+
+field1 = NXfield((1,2), name="f1")
+field2 = NXfield((3,4), name="f2")
+field3 = NXfield((5,6), name="f3")
+
+
+def test_file_creation(tmpdir):
+
+    filename = os.path.join(tmpdir, 'file.nxs')
+    with NXFile(filename, 'w') as f:
+        assert f.mode == 'rw'
+        assert f.filename == filename
+    assert not f.is_open()
+
+
+def test_file_save(tmpdir):
+
+    filename = os.path.join(tmpdir, 'file.nxs')
+
+    w1 = NXroot(NXentry())
+    w1.entry.data = NXdata(field1, field2)
+    w1.save(filename)
+
+    assert os.path.exists(filename)
+    assert not w1.nxfile.is_open()
+    assert w1.nxfilename == filename
+    assert w1.nxfilemode == 'rw'
+
+    w2 = nxload(filename)
+    assert w2.nxfilename == filename
+    assert w2.nxfilemode == 'r'
+    assert 'entry/data/f1' in w2
+    assert 'entry/data/f2' in w2
+    assert 'signal' in w2['entry/data'].attrs
+    assert 'axes' in w2['entry/data'].attrs

--- a/tests/test_groups.py
+++ b/tests/test_groups.py
@@ -101,7 +101,7 @@ def test_group_move():
     group['g2/f2'] = NXlink(target='g1/f1')
     group['g2'].move('f2', 'g3', name='f3')
 
-    assert group['g3/f3'].nxlink is group['g1/f1']
+    assert group['g3/f3'].nxlink == field1
 
     
 def test_group_copy():

--- a/tests/test_groups.py
+++ b/tests/test_groups.py
@@ -1,7 +1,4 @@
-import h5py as h5
-import numpy as np
 import pytest
-import six
 from nexusformat.nexus import *
 
 

--- a/tests/test_groups.py
+++ b/tests/test_groups.py
@@ -12,10 +12,12 @@ field3 = NXfield((5,6), name="f3")
 
 def test_group_creation():
 
-    group1 = NXgroup()
+    group1 = NXgroup(name="group")
 
     assert len(group1) == 0
-    
+    assert group1.nxname == "group"
+    assert group1.nxgroup is None
+
     group2 = NXgroup(field1)
 
     assert len(group2) == 1
@@ -35,11 +37,13 @@ def test_group_creation():
 
     assert "f3" in group1["g2"]
     assert "g2/f3" in group1
+    assert group1["g2/f3"].nxgroup == group1["g2"]
 
     group3 = NXgroup(g1=group1)
 
     assert "g1/g2/f1" in group3
-    
+    assert group3["g1"].nxgroup == group3    
+
 
 def test_group_insertion():
 
@@ -60,9 +64,60 @@ def test_entry_creation():
     assert isinstance(group, NXentry)
 
 
+def test_group_class():
+
+    group = NXgroup()
+    group.nxclass = NXentry
+    
+    assert group.nxclass == "NXentry"
+    assert isinstance(group, NXentry)
+
+
 def test_group_title():
 
     group = NXentry()
     group["title"] = "Group Title"
 
     assert group.nxtitle == "Group Title"
+
+
+def test_group_move():
+
+    group = NXentry()
+    group['g1'] = NXgroup()
+    group['g1/f1'] = field1
+    group['g2'] = NXgroup()
+    group['g1'].move('f1', 'g2', name='f2')
+
+    assert 'g1/f1' not in group
+    assert 'g2/f2' in group
+
+    group['g2'].move(group['g2/f2'], group['g1'], name='f1')
+
+    assert 'g2/f2' not in group
+    assert 'g1/f1' in group
+
+    group['g3'] = NXgroup()
+    group['g2/f2'] = NXlink(target='g1/f1')
+    group['g2'].move('f2', 'g3', name='f3')
+
+    assert group['g3/f3'].nxlink is group['g1/f1']
+
+    
+def test_group_copy():
+
+    group = NXentry()
+    group['g1'] = NXgroup()
+    group['g1/g2'] = NXgroup()
+    group['g1/g2/f1'] = field1
+
+    new_group = group['g1/g2'].copy()
+    assert new_group.entries == group['g1/g2'].entries
+    assert id(new_group['f1']) != id(group['g1/g2/f1'])
+
+    group['g3'] = NXgroup()
+    group['g1/g2'].copy(group['g3'], name='g4')
+
+    assert 'g3/g4/f1' in group
+    assert group['g1/g2/f1'] == group['g3/g4/f1']
+

--- a/tests/test_links.py
+++ b/tests/test_links.py
@@ -29,12 +29,20 @@ def test_link_creation():
     assert root["g2/f3_link"].nxlink is root["g1/f1"]
 
 
-def test_linkfield_properties():
+@pytest.mark.parametrize("save", ["False", "True"])
+def test_saved_links(tmpdir, save):
 
     root = NXroot()    
     root["g1"] = NXgroup(f1=field1)
     root["g2"] = NXgroup()
+
+    filename = os.path.join(tmpdir, "file1.nxs")
+    root.save(filename, mode="w")
+
     root["g2"].f1_link = NXlink(root["g1/f1"])
+
+    if save:
+        root = nxload(filename)
 
     assert root["g2/f1_link"].shape == (2,)
     assert root["g2/f1_link"].dtype == np.float32
@@ -45,16 +53,44 @@ def test_linkfield_properties():
     assert root["g2/f1_link"].a1 == 1
 
 
-def test_linkgroup_properties():
+@pytest.mark.parametrize("save", ["False", "True"])
+def test_linkfield_properties(tmpdir, save):
+
+    root = NXroot()    
+    root["g1"] = NXgroup(f1=field1)
+    root["g2"] = NXgroup()
+    root["g2"].f1_link = NXlink(root["g1/f1"])
+
+    if save:
+        filename = os.path.join(tmpdir, "file1.nxs")
+        root.save(filename, mode="w")
+        root = nxload(filename)
+
+    assert root["g2/f1_link"].shape == (2,)
+    assert root["g2/f1_link"].dtype == np.float32
+
+    root["g1/f1"].attrs["a1"] = 1
+
+    assert "a1" in root["g2/f1_link"].attrs
+    assert root["g2/f1_link"].a1 == 1
+
+
+@pytest.mark.parametrize("save", ["False", "True"])
+def test_linkgroup_properties(tmpdir, save):
 
     root = NXroot(NXentry())    
     root["entry/g1"] = NXgroup()
     root["entry/g1/g2"] = NXgroup(field1)
     root["entry/g3"] = NXlink("entry/g1/g2")
 
+    if save:
+        filename = os.path.join(tmpdir, "file1.nxs")
+        root.save(filename, mode="w")
+        root = nxload(filename)
+
     assert "f1" in root["entry/g3"]
     assert len(root["entry/g3"]) == len(root["entry/g1/g2"])
-    assert root["entry/g3"].nxtarget == "entry/g1/g2"
+    assert root["entry/g3"].nxtarget == "/entry/g1/g2"
     assert root["entry/g1/g2/f1"].nxgroup is root["entry/g1/g2"]
     assert root["entry/g3"].nxgroup is root["entry"]
     assert root["entry/g3"].nxlink is root["entry/g1/g2"]
@@ -70,10 +106,10 @@ def test_external_field_links(tmpdir):
     external_root = NXroot(NXentry(field1))
     external_root.save(external_filename, mode="w")
 
-    root["entry/f2"] = NXlink(target="entry/f1", file=external_filename)
+    root["entry/f2"] = NXlink(target="/entry/f1", file=external_filename)
 
-    assert root["entry/f2"].nxtarget == "entry/f1"
-    assert root["entry/f2"].nxfilepath == "entry/f1"
+    assert root["entry/f2"].nxtarget == "/entry/f1"
+    assert root["entry/f2"].nxfilepath == "/entry/f1"
     assert root["entry/f2"].nxfilename == external_filename
     assert root["entry/f2"].nxfilemode == "r"
     assert root["entry/f2"].nxgroup == root["entry"]
@@ -95,10 +131,10 @@ def test_external_group_links(tmpdir):
     external_root = NXroot(NXentry(NXgroup(field1, name='g1', attrs={"a":"b"})))
     external_root.save(external_filename, mode="w")
 
-    root["entry/g2"] = NXlink(target="entry/g1", file=external_filename)
+    root["entry/g2"] = NXlink(target="/entry/g1", file=external_filename)
 
-    assert root["entry/g2"].nxtarget == "entry/g1"
-    assert root["entry/g2"].nxfilepath == "entry/g1"
+    assert root["entry/g2"].nxtarget == "/entry/g1"
+    assert root["entry/g2"].nxfilepath == "/entry/g1"
     assert root["entry/g2"].nxfilename == external_filename
     assert root["entry/g2"].nxfilemode == "r"
     assert root["entry/g2"].nxgroup == root["entry"]
@@ -122,9 +158,10 @@ def test_external_group_files(tmpdir):
     external_root = NXroot(NXentry(NXgroup(field1, name='g1', attrs={"a":"b"})))
     external_root.save(external_filename, mode="w")
 
-    root["entry/g2"] = NXlink(target="entry/g1", file=external_filename)
+    root["entry/g2"] = NXlink(target="/entry/g1", file=external_filename)
     with root.nxfile:
 
+        assert root.nxfile.filename == filename
         assert root.nxfile.locked
         
         with root["entry/g2"].nxfile:

--- a/tests/test_links.py
+++ b/tests/test_links.py
@@ -83,6 +83,7 @@ def test_external_field_links(tmpdir):
     assert root["entry/f2"][0] == external_root["entry/f1"][0]
     assert "units" in root["entry/f2"].attrs
 
+
 def test_external_group_links(tmpdir):
 
     filename = os.path.join(tmpdir, "file1.nxs")

--- a/tests/test_locks.py
+++ b/tests/test_locks.py
@@ -72,7 +72,7 @@ def test_lock_interactions(tmpdir):
     root = NXroot(NXentry(field1))
     root.save(filename)
 
-    assert not root.nxfile.isopen()
+    assert not root.nxfile.is_open()
 
     root1 = nxload(filename, mode="rw")
     root2 = nxload(filename, mode="r")

--- a/tests/test_locks.py
+++ b/tests/test_locks.py
@@ -2,12 +2,12 @@ import os
 import pytest
 from nexusformat.nexus import *
 
-
 field1 = NXfield('a', name="f1")
 
 
 def test_lock_creation(tmpdir):
 
+    nxsetlock(0)
     filename = os.path.join(tmpdir, "file1.nxs")
     root = NXroot(NXentry(field1))
     root.save(filename)
@@ -91,6 +91,7 @@ def test_lock_defaults(tmpdir):
     root.save(filename, "w")
 
     with root.nxfile as f:
+
         assert isinstance(root.nxfile.lock, NXLock)
         assert root.nxfile.lock.timeout == 20
         assert root.nxfile.locked
@@ -104,6 +105,7 @@ def test_lock_defaults(tmpdir):
     root.save(filename, "w")
 
     with root.nxfile as f:
+
         assert not root.nxfile.locked
         assert not root.nxfile.is_locked()
 

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -1,0 +1,47 @@
+import pytest
+from nexusformat.nexus import *
+
+
+field1 = NXfield((1,2), name="f1")
+
+
+def test_attribute_paths():
+
+    root = NXroot(NXentry())
+    root.entry.g1 = NXgroup(field1)
+
+    assert root.entry.g1.nxpath == "/entry/g1"
+    assert root["entry/g1"] is root.entry.g1
+    assert root["entry/g1/f1"] is root.entry.g1.f1
+    assert "g1" in root.entry
+    assert "f1" in root.entry.g1
+    assert "entry/g1/f1" in root
+    assert root.entry.g1.f1.nxroot is root
+
+
+def test_dictionary_paths():
+
+    root = NXroot(NXentry())
+    root["entry/g1"] = NXgroup(field1)
+
+    assert root.entry.g1.nxpath == "/entry/g1"
+    assert root["entry/g1"] is root.entry.g1
+    assert root["entry/g1/f1"] is root.entry.g1.f1
+    assert "g1" in root["/entry"]
+    assert "f1" in root["/entry/g1"]
+    assert "/entry/g1/f1" in root
+    assert root["/entry/g1/f1"].nxroot is root
+
+
+def test_relative_paths():
+
+    root = NXroot(NXentry())
+    root["entry/g1"] = NXgroup()
+    root["entry/g1/g2"] = NXgroup()
+    root["entry/g1/g2/f1"] = field1
+
+    assert "f1" in root["entry/g1/g2"]
+    assert "g2/f1" in root["entry/g1"]
+    assert "g1/g2/f1" in root["entry"]
+    assert root["entry/g1/g2/f1"].nxpath == "/entry/g1/g2/f1"
+    assert "entry" in root


### PR DESCRIPTION
* Adds a `copy` function to NXfields and NXgroups to allow h5py keyword arguments, *e.g.* `expand_external`, to be used when copying between files.
* Adds a `move` function to NXgroups to allow group entries to be transferred to another group. 
* Ensures that all `NXlink` targets are absolute paths.
