### PR TITLE
Redo links

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,6 @@
+[bdist_rpm]
+requires = h5py,numpy,scipy
+
 [versioneer]
 VCS = git
 style = pep440

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -2616,9 +2616,9 @@ class NXfield(NXobject):
 
     def __repr__(self):
         if self._value is not None:
-            return "NXfield(%s, id=%s)" % (repr(self.nxvalue), id(self))
+            return "NXfield(%s)" % repr(self.nxvalue)
         else:
-            return "NXfield(shape=%s, dtype=%s, id=%s)" % (self.shape, self.dtype, id(self))
+            return "NXfield(shape=%s, dtype=%s)" % (self.shape, self.dtype)
 
     def __str__(self):
         if self._value is not None:
@@ -4152,7 +4152,7 @@ class NXgroup(NXobject):
                       key=natural_sort)
 
     def __repr__(self):
-        return "%s('%s' id=%s)" % (self.__class__.__name__, self.nxname, id(self))
+        return "%s('%s')" % (self.__class__.__name__, self.nxname)
 
     def __hash__(self):
         return id(self)
@@ -4912,9 +4912,8 @@ class NXlink(NXobject):
 
     def __repr__(self):
         if self._filename:
-            return "NXlink(target='%s', file='%s' id=%s)" % (self._target, 
-                                                             self._filename,
-                                                             id(self))
+            return "NXlink(target='%s', file='%s')" % (self._target, 
+                                                       self._filename)
         else:
             return "NXlink('%s')" % (self._target)
 

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -5000,11 +5000,9 @@ class NXlink(NXobject):
                 with self.nxfile as f:
                     item = f.readpath(self.nxfilepath)
                 self._link = self.external_link
-                self._external = True
             elif self._target in self.nxroot:
                 item = self.nxroot[self._target]
                 self._link = self.internal_link
-                self._external = False
             else:
                 self._link = None
                 return None
@@ -5052,15 +5050,6 @@ class NXlink(NXobject):
     def abspath(self):
         """True if the filename is to be stored as an absolute path."""
         return self._abspath
-
-    def is_external(self):
-        """True if the linked object is in an external file."""
-        if self._external is None:
-            if self._filename is not None:
-                self._external = True
-            else:
-                self._external = super(NXlink, self).is_external()
-        return self._external
 
 
 class NXlinkfield(NXlink, NXfield):

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -5113,19 +5113,16 @@ class NXlinkgroup(NXlink, NXgroup):
         dict of NXfields and/or NXgroups
             Dictionary of group objects.
         """
+        _linked_entries = self.nxlink.entries
         _entries = {}
-        try:
-            for entry in self.nxlink.entries:
-        _entries = self.nxlink.entries
         if self.is_external():
-            for entry in _entries:
+            for entry in _linked_entries:
+                _entries[entry] = _linked_entries[entry]
                 _entries[entry]._group = self
-        else:
-            for entry in _entries:
-                _entries[entry] = deepcopy(self.nxlink[entry])
+        else:            
+            for entry in _linked_entries:
+                _entries[entry] = deepcopy(_linked_entries[entry])
                 _entries[entry]._group = self
-        except Exception as error:
-            pass
         return _entries
 
 

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -4895,7 +4895,6 @@ class NXlink(NXobject):
             if not self._target.startswith('/'):
                 self._target = '/' + self._target
         self._link = None
-        self._initialized = False
 
     def __repr__(self):
         if self._filename:
@@ -5014,7 +5013,7 @@ class NXlink(NXobject):
         NXfield or NXgroup
             Target of link.
         """
-        if not self._initialized:
+        if self.nxclass == 'NXlink':
             if self.is_external():
                 if os.path.exists(self.nxfilename):
                     with self.nxfile as f:
@@ -5031,7 +5030,6 @@ class NXlink(NXobject):
                 self._setclass(_getclass(item.nxclass, link=True))
             else:
                 return
-            self._initialized = True
 
     @property
     def internal_link(self):
@@ -5084,7 +5082,6 @@ class NXlinkfield(NXlink, NXfield):
         NXlink.__init__(self, target=target, file=file, name=name, 
                         abspath=abspath)
         self._class = "NXfield"
-        self._initialized = True
 
 
 class NXlinkgroup(NXlink, NXgroup):
@@ -5096,7 +5093,6 @@ class NXlinkgroup(NXlink, NXgroup):
                         abspath=abspath)
         if 'nxclass' in kwargs:
             self._setclass(_getclass(kwargs['nxclass'], link=True))
-            self._initialized = True
         else:
             self._class = 'NXlink'
         self._entries = {}

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -4248,6 +4248,8 @@ class NXgroup(NXobject):
                         raise NeXusError("Invalid path")
             if group.nxfilemode == 'r':
                 raise NeXusError("NeXus group marked as readonly")
+            elif isinstance(group, NXlink):
+                raise NeXusError("Cannot modify an item in a linked group")
             elif isinstance(value, NXroot):
                 raise NeXusError(
                     "Cannot assign an NXroot group to another group")
@@ -4260,6 +4262,8 @@ class NXgroup(NXobject):
                         "Cannot assign an NXlink to an existing group entry")
                 elif isinstance(group.entries[key], NXlink):
                     raise NeXusError("Cannot assign values to an NXlink")
+                elif group.entries[key].is_linked():
+                    raise NeXusError("Cannot modify an item in linked group")
                 group.entries[key].nxdata = value
                 if isinstance(value, NXfield):
                     group.entries[key]._setattrs(value.attrs)
@@ -4322,6 +4326,8 @@ class NXgroup(NXobject):
                         raise NeXusError("Invalid path")
             if key not in group:
                 raise NeXusError("'"+key+"' not in "+group.nxpath)
+            elif group[key].is_linked():
+                raise NeXusError("Cannot delete an item in a linked group")
             if group.nxfilemode == 'rw':
                 with group.nxfile as f:
                     if 'mask' in group.entries[key].attrs:

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -3032,11 +3032,17 @@ class NXfield(NXobject):
 
     def any(self):
         """Return False if all values are 0 or False, True otherwise."""
-        return np.any(self.nxvalue)
+        try:
+            return np.any(self.nxvalue)
+        except TypeError as error:
+            raise NeXusError("Invalid field type for numeric comparisons")
 
     def all(self):
         """Return False if any values are 0 or False, True otherwise."""
-        return np.all(self.nxvalue)
+        try:
+            return np.all(self.nxvalue)
+        except TypeError as error:
+            raise NeXusError("Invalid field type for numeric comparisons")
 
     def index(self, value, max=False):
         """Return the index of a value in a one-dimensional NXfield.

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -2327,6 +2327,13 @@ class NXobject(object):
         """True if the NeXus object is plottable."""
         return False
 
+    def is_modifiable(self):
+        _mode = self.nxfilemode
+        if _mode is None or _mode == 'rw' and not self.is_linked():
+            return True
+        else:
+            return False 
+
     def is_linked(self):
         """True if the NeXus object is embedded in a link."""
         if self._group is not None:

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -2329,10 +2329,11 @@ class NXobject(object):
 
     def is_linked(self):
         """True if the NeXus object is embedded in a link."""
-        if isinstance(self, NXlink):
-            return True
-        elif self._group is not None:
-            return self._group.is_linked()
+        if self._group is not None:
+            if isinstance(self._group, NXlink):
+                return True
+            else:
+                return self._group.is_linked()
         else:
             return False
 

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -5020,12 +5020,10 @@ class NXlink(NXobject):
         External links are always read-only.
         """
         try:
-            if self._mode is None:
-                if self.is_external():
-                    self._mode = 'r'
-                else:
-                    self._mode = self.nxlink.nxfilemode
-            return self._mode
+            if self.is_external():
+                return 'r'
+            else:
+                return self.nxlink.nxfilemode
         except Exception:
             return 'r'
 

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -5049,7 +5049,10 @@ class NXlink(NXobject):
 
     @property
     def attrs(self):
-        return self.nxlink.attrs
+        try:
+            return self.nxlink.attrs
+        except NeXusError:
+            return AttrDict()
 
     @property
     def nxfilemode(self):

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -742,10 +742,10 @@ class NXFile(object):
             group = NXlinkgroup(nxclass=nxclass, name=name, target=_target,
                                 file=_filename, abspath=_abspath)
         else:
-            group = NXgroup(nxclass=nxclass, name=name, attrs=attrs,
-                            new_entries=children)
-        for obj in children.values():
-            obj._group = group
+            group = NXgroup(nxclass=nxclass, name=name, attrs=attrs)
+        for child in children:
+            group._entries[child] = children[child]
+            children[child]._group = group
         group._changed = True
         return group
 
@@ -4100,10 +4100,6 @@ class NXgroup(NXobject):
             for k,v in kwargs["entries"].items():
                 self._entries[k] = deepcopy(v)
             del kwargs["entries"]
-        if "new_entries" in kwargs:
-            for k,v in kwargs["new_entries"].items():
-                self._entries[k] = v
-            del kwargs["new_entries"]            
         if "attrs" in kwargs:
             self._attrs = AttrDict(self, attrs=kwargs["attrs"])
             del kwargs["attrs"]

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -1894,6 +1894,12 @@ class NXobject(object):
     def __repr__(self):
         return "NXobject('%s')" % (self.nxname)
 
+    def __bool__(self):
+        """Return confirmation that the object exists."""
+        return True
+
+    __nonzero__ = __bool__
+
     def __contains__(self, key):
         return False
 
@@ -3024,16 +3030,13 @@ class NXfield(NXobject):
         except Exception:
             return 0
 
-    def __nonzero__(self):
+    def any(self):
         """Return False if all values are 0 or False, True otherwise."""
-        try:
-            if np.any(self.nxvalue):
-                return True
-            else:
-                return False
-        except NeXusError:
-            #This usually means that there are too many values to load
-            return True
+        return np.any(self.nxvalue)
+
+    def all(self):
+        """Return False if any values are 0 or False, True otherwise."""
+        return np.all(self.nxvalue)
 
     def index(self, value, max=False):
         """Return the index of a value in a one-dimensional NXfield.
@@ -4380,12 +4383,6 @@ class NXgroup(NXobject):
     def __len__(self):
         """Return the number of entries in the group."""
         return len(self.entries)
-
-    def __bool__(self):
-        """Return confirmation that the group exists."""
-        return True
-
-    __nonzero__ = __bool__
 
     def __deepcopy__(self, memo):
         """Return a deep copy of the group."""

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -5087,6 +5087,13 @@ class NXlinkgroup(NXlink, NXgroup):
             self._setclass(_getclass(kwargs['nxclass'], link=True))
         else:
             self._class = 'NXlink'
+    def __getattr__(self, name):
+        """Return attribute looking in the group entries and attributes.
+
+        If the attribute is the name of a defined NeXus class, a list of group
+        entries of that class are returned.
+        """
+        return NXgroup(self).__getattr__(name)
 
     def _str_name(self, indent=0):
         if self._filename:

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -5061,21 +5061,6 @@ class NXlinkfield(NXlink, NXfield):
                         abspath=abspath)
         self._class = "NXfield"
 
-    def __getitem__(self, idx):
-        """Return slice from the target NXfield.
-        
-        Parameters
-        ----------
-        idx : slice
-            Indices defining the slice.
-        
-        Returns
-        -------
-        NXfield
-            Field containing the slice values.
-        """
-        return self.nxlink.__getitem__(idx)
-
 
 class NXlinkgroup(NXlink, NXgroup):
     """Class for NeXus linked groups."""
@@ -5117,6 +5102,12 @@ class NXlinkgroup(NXlink, NXgroup):
         _entries = {}
         try:
             for entry in self.nxlink.entries:
+        _entries = self.nxlink.entries
+        if self.is_external():
+            for entry in _entries:
+                _entries[entry]._group = self
+        else:
+            for entry in _entries:
                 _entries[entry] = deepcopy(self.nxlink[entry])
                 _entries[entry]._group = self
         except Exception as error:

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -22,6 +22,8 @@ def test_data_creation():
     assert data.nxsignal.nxname == "v"
     assert data.nxsignal.ndim == 3
     assert data.nxsignal.shape == (2, 5, 10)
+    assert data.nxsignal.any()
+    assert not data.nxsignal.all()
     assert [axis.nxname for axis in data.nxaxes] == ["z", "y", "x"]
     assert [axis.ndim for axis in data.nxaxes] == [1, 1, 1]
     assert [axis.shape for axis in data.nxaxes] == [(3,), (6,), (11,)]

--- a/tests/test_links.py
+++ b/tests/test_links.py
@@ -91,7 +91,7 @@ def test_linkgroup_properties(tmpdir, save):
     assert len(root["entry/g2_link"]) == len(root["entry/g1/g2"])
     assert root["entry/g2_link"].nxtarget == "/entry/g1/g2"
     assert root["entry/g1/g2/f1"].nxroot is root
-    assert root["entry/g1/g2/f1"].nxgroup is root["entry/g1/g2"]
+    assert root["entry/g1/g2/f1"].nxgroup is root["entry/g2_link"].nxlink
     assert root["entry/g2_link"].nxroot is root
     assert root["entry/g2_link"].nxgroup is root["entry"]
     assert root["entry/g2_link"].nxlink.entries == root["entry/g1/g2"].entries
@@ -109,18 +109,32 @@ def test_embedded_links(tmpdir, save):
     if save:
         filename = os.path.join(tmpdir, "file1.nxs")
         root.save(filename, mode="w")
-        root = nxload(filename)
+        root = nxload(filename, "rw")
 
     assert "f1" in root["entry/g2_link/g3"]
+    assert not root["entry/g2_link"].is_linked()
+    assert root["entry/g2_link/g3"].is_linked()
+    assert root["entry/g2_link/g3/f1"].is_linked()
     assert len(root["entry/g2_link/g3"]) == len(root["entry/g1/g2/g3"])
     assert root["entry/g2_link/g3/f1"].nxpath == "/entry/g2_link/g3/f1"
     assert root["entry/g2_link/g3/f1"].nxfilepath == "/entry/g1/g2/g3/f1"
     assert root["entry/g2_link/g3/f1"].nxroot is root
     assert root["entry/g2_link/g3/f1"].nxgroup.nxgroup is root["entry/g2_link"]
 
-    root["entry/g2_link/g3/f1"].attrs["a"] = 1
+    root["entry/g1/g2/g3/f1"] = [7, 8]
+    root["entry/g1/g2/g3/f1"].attrs["a"] = 1
 
-    assert "a" in root["entry/g1/g2/g3/f1"].attrs
+    assert root["entry/g2_link/g3/f1"][0] == 7
+    assert "a" in root["entry/g2_link/g3/f1"].attrs
+    assert root["entry/g2_link/g3/f1"].attrs["a"] == 1
+
+    root["entry/g1/g2/g3/f2"] = field2
+
+    assert "f2" in root["entry/g2_link/g3"]
+
+    del root["entry/g1/g2/g3/f2"]
+
+    assert "f2" not in root["entry/g2_link/g3"]
 
 
 def test_external_field_links(tmpdir):

--- a/tests/test_links.py
+++ b/tests/test_links.py
@@ -18,15 +18,15 @@ def test_link_creation():
 
     assert "g1/f1" in root
     assert "g2/f1_link" in root
-    assert root["g2/f1_link"].nxlink is root["g1/f1"]
+    assert root["g2/f1_link"].nxlink == root["g1/f1"]
     assert root["g2/f1_link"].nxtarget == "/g1/f1"
 
     root["g2/f2_link"] = NXlink(target="/g1/f1")
 
-    assert root["g2/f2_link"].nxlink is root["g1/f1"]
+    assert root["g2/f2_link"].nxlink == root["g1/f1"]
 
     root["g2"].makelink(root["g1/f1"], name="f3_link")
-    assert root["g2/f3_link"].nxlink is root["g1/f1"]
+    assert root["g2/f3_link"].nxlink == root["g1/f1"]
 
 
 @pytest.mark.parametrize("save", ["False", "True"])
@@ -80,21 +80,47 @@ def test_linkgroup_properties(tmpdir, save):
     root = NXroot(NXentry())    
     root["entry/g1"] = NXgroup()
     root["entry/g1/g2"] = NXgroup(field1)
-    root["entry/g3"] = NXlink("entry/g1/g2")
+    root["entry/g2_link"] = NXlink("entry/g1/g2")
 
     if save:
         filename = os.path.join(tmpdir, "file1.nxs")
         root.save(filename, mode="w")
         root = nxload(filename)
 
-    assert "f1" in root["entry/g3"]
-    assert len(root["entry/g3"]) == len(root["entry/g1/g2"])
-    assert root["entry/g3"].nxtarget == "/entry/g1/g2"
+    assert "f1" in root["entry/g2_link"]
+    assert len(root["entry/g2_link"]) == len(root["entry/g1/g2"])
+    assert root["entry/g2_link"].nxtarget == "/entry/g1/g2"
     assert root["entry/g1/g2/f1"].nxroot is root
     assert root["entry/g1/g2/f1"].nxgroup is root["entry/g1/g2"]
-    assert root["entry/g3"].nxroot is root
-    assert root["entry/g3"].nxgroup is root["entry"]
-    assert root["entry/g3"].nxlink is root["entry/g1/g2"]
+    assert root["entry/g2_link"].nxroot is root
+    assert root["entry/g2_link"].nxgroup is root["entry"]
+    assert root["entry/g2_link"].nxlink.entries == root["entry/g1/g2"].entries
+
+
+@pytest.mark.parametrize("save", ["False", "True"])
+def test_embedded_links(tmpdir, save):
+
+    root = NXroot(NXentry())    
+    root["entry/g1"] = NXgroup()
+    root["entry/g1/g2"] = NXgroup()
+    root["entry/g1/g2/g3"] = NXgroup(field1)
+    root["entry/g2_link"] = NXlink("entry/g1/g2")
+
+    if save:
+        filename = os.path.join(tmpdir, "file1.nxs")
+        root.save(filename, mode="w")
+        root = nxload(filename)
+
+    assert "f1" in root["entry/g2_link/g3"]
+    assert len(root["entry/g2_link/g3"]) == len(root["entry/g1/g2/g3"])
+    assert root["entry/g2_link/g3/f1"].nxpath == "/entry/g2_link/g3/f1"
+    assert root["entry/g2_link/g3/f1"].nxfilepath == "/entry/g1/g2/g3/f1"
+    assert root["entry/g2_link/g3/f1"].nxroot is root
+    assert root["entry/g2_link/g3/f1"].nxgroup.nxgroup is root["entry/g2_link"]
+
+    root["entry/g2_link/g3/f1"].attrs["a"] = 1
+
+    assert "a" in root["entry/g1/g2/g3/f1"].attrs
 
 
 def test_external_field_links(tmpdir):
@@ -107,20 +133,20 @@ def test_external_field_links(tmpdir):
     external_root = NXroot(NXentry(field1))
     external_root.save(external_filename, mode="w")
 
-    root["entry/f2"] = NXlink(target="/entry/f1", file=external_filename)
+    root["entry/f1_link"] = NXlink(target="/entry/f1", file=external_filename)
 
-    assert root["entry/f2"].nxtarget == "/entry/f1"
-    assert root["entry/f2"].nxfilepath == "/entry/f1"
-    assert root["entry/f2"].nxfilename == external_filename
-    assert root["entry/f2"].nxfilemode == "r"
-    assert root["entry/f2"].nxroot == root
-    assert root["entry/f2"].nxgroup == root["entry"]
+    assert root["entry/f1_link"].nxtarget == "/entry/f1"
+    assert root["entry/f1_link"].nxfilepath == "/entry/f1"
+    assert root["entry/f1_link"].nxfilename == external_filename
+    assert root["entry/f1_link"].nxfilemode == "r"
+    assert root["entry/f1_link"].nxroot == root
+    assert root["entry/f1_link"].nxgroup == root["entry"]
 
-    assert root["entry/f2"].file_exists()
-    assert root["entry/f2"].path_exists()
-    assert root["entry/f2"].shape == external_root["entry/f1"].shape
-    assert root["entry/f2"][0] == external_root["entry/f1"][0]
-    assert "units" in root["entry/f2"].attrs
+    assert root["entry/f1_link"].file_exists()
+    assert root["entry/f1_link"].path_exists()
+    assert root["entry/f1_link"].shape == external_root["entry/f1"].shape
+    assert root["entry/f1_link"][0] == external_root["entry/f1"][0]
+    assert "units" in root["entry/f1_link"].attrs
 
 
 def test_external_group_links(tmpdir):
@@ -133,26 +159,26 @@ def test_external_group_links(tmpdir):
     external_root = NXroot(NXentry(NXgroup(field1, name='g1', attrs={"a":"b"})))
     external_root.save(external_filename, mode="w")
 
-    root["entry/g2"] = NXlink(target="/entry/g1", file=external_filename)
+    root["entry/g1_link"] = NXlink(target="/entry/g1", file=external_filename)
     
-    assert root["entry/g2"].nxtarget == "/entry/g1"
-    assert root["entry/g2"].nxfilepath == "/entry/g1"
-    assert root["entry/g2"].nxfilename == external_filename
-    assert root["entry/g2"].nxfilemode == "r"
-    assert root["entry/g2"].nxroot == root
-    assert root["entry/g2"].nxgroup == root["entry"]
-    assert root["entry/g2"].file_exists()
-    assert root["entry/g2"].path_exists()
+    assert root["entry/g1_link"].nxtarget == "/entry/g1"
+    assert root["entry/g1_link"].nxfilepath == "/entry/g1"
+    assert root["entry/g1_link"].nxfilename == external_filename
+    assert root["entry/g1_link"].nxfilemode == "r"
+    assert root["entry/g1_link"].nxroot == root
+    assert root["entry/g1_link"].nxgroup == root["entry"]
+    assert root["entry/g1_link"].file_exists()
+    assert root["entry/g1_link"].path_exists()
 
-    assert "f1" in root["entry/g2"]
-    assert root["entry/g2/f1"].nxfilename == root["entry/g2"].nxfilename
-    assert root["entry/g2/f1"].nxfilepath == "/entry/g1/f1"
-    assert root["entry/g2/f1"].nxroot == root
-    assert root["entry/g2/f1"].nxgroup is root["entry/g2"]
-    assert root["entry/g2/f1"][0] == external_root["entry/g1/f1"][0]
+    assert "f1" in root["entry/g1_link"]
+    assert root["entry/g1_link/f1"].nxfilename == root["entry/g1_link"].nxfilename
+    assert root["entry/g1_link/f1"].nxfilepath == "/entry/g1/f1"
+    assert root["entry/g1_link/f1"].nxroot == root
+    assert root["entry/g1_link/f1"].nxgroup is root["entry/g1_link"]
+    assert root["entry/g1_link/f1"][0] == external_root["entry/g1/f1"][0]
 
-    assert "a" in root["entry/g2"].attrs
-    assert "units" in root["entry/g2/f1"].attrs
+    assert "a" in root["entry/g1_link"].attrs
+    assert "units" in root["entry/g1_link/f1"].attrs
 
 
 def test_external_group_files(tmpdir):
@@ -167,18 +193,18 @@ def test_external_group_files(tmpdir):
     external_root = NXroot(NXentry(NXgroup(field1, name='g1', attrs={"a":"b"})))
     external_root.save(external_filename, mode="w")
 
-    root["entry/g2"] = NXlink(target="/entry/g1", file=external_filename)
+    root["entry/g1_link"] = NXlink(target="/entry/g1", file=external_filename)
     with root.nxfile:
 
         assert root.nxfile.filename == filename
         assert root.nxfile.locked
         
-        with root["entry/g2"].nxfile:
+        with root["entry/g1_link"].nxfile:
 
-            assert root["entry/g2"].nxfile.filename == external_filename
-            assert root["entry/g2"].nxfile.locked
+            assert root["entry/g1_link"].nxfile.filename == external_filename
+            assert root["entry/g1_link"].nxfile.locked
 
         assert root.nxfile.locked
-        assert not root["entry/g2"].nxfile.locked
+        assert not root["entry/g1_link"].nxfile.locked
 
     assert not root.nxfile.locked

--- a/tests/test_locks.py
+++ b/tests/test_locks.py
@@ -80,6 +80,8 @@ def test_lock_interactions(tmpdir):
     root1 = nxload(filename, mode="rw")
     root2 = nxload(filename, mode="r")
 
+    time.sleep(0.1)
+
     root1.nxfile.lock = 10
     root1["entry/f1"] = "b"
 


### PR DESCRIPTION
* Fixes handling of data embedded in linked groups. These are now dynamically updated when the target group is changed.
* Prevents changes directly to data embedded in linked groups. Now such changes should be made directly to the target, which is accessible through the linked group's `nxlink` attribute.
* Improves error reporting when data updates are not allowed.
* Adds new `any` and `all` functions too NXfields. Now, the `__bool__` function is only used to test for the existence of an NXobject.