### PR TITLE
Catch exception in reading file in path_exists

### DIFF
--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -2351,8 +2351,11 @@ class NXobject(object):
         """True if the path to the NeXus object exists."""
         if self.is_external():
             if self.file_exists():
-                with self.nxfile as f:
-                    return self.nxfilepath in f
+                try:
+                    with self.nxfile as f:
+                        return self.nxfilepath in f
+                except Exception as error:
+                    return False
             else:
                 return False
         else:


### PR DESCRIPTION
* If the file is unreadable, this records that the path does not exist without raising an exception.