### PR TITLE
Improve defaults

### DIFF
--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -4767,7 +4767,7 @@ class NXgroup(NXobject):
         else:
             return None
 
-    def set_default(self):
+    def set_default(self, over=False):
         """Set the current group as the default for plotting.
         
         This function is overridden by the NXentry and NXdata classes. For all
@@ -5306,6 +5306,16 @@ class NXroot(NXgroup):
         if self.nxfile:
             self.nxfile.close()
 
+    def set_default(self, over=False):
+        """Override function to set default for plotting.
+        
+        Parameters
+        ==========
+        over : bool
+            True if previous default should be overwritten
+        """
+        pass
+
     @property
     def plottable_data(self):
         """The default data group to be plotted in this tree.
@@ -5447,6 +5457,11 @@ class NXentry(NXgroup):
         
         This will set defaults for parents of the parent group unless they have
         been set previously.
+        
+        Parameters
+        ==========
+        over : bool
+            True if previous default should be overwritten
         """
         group = self.nxgroup
         if group is None:
@@ -5454,7 +5469,6 @@ class NXentry(NXgroup):
                 "The default cannot be defined without a parent group")
         elif isinstance(group, NXentry) or isinstance(group, NXroot):
             group.attrs['default'] = self.nxname
-            parent_group = group.nxgroup
             parent_group = group.nxgroup
             if parent_group:
                 if over or parent_group.get_default() is None:
@@ -6099,7 +6113,7 @@ class NXdata(NXgroup):
         Parameters
         ==========
         over : bool
-            True if previous defa
+            True if previous default should be overwritten
         """
         group = self.nxgroup
         if group is None:

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -4753,6 +4753,29 @@ class NXgroup(NXobject):
         """
         return np.sqrt(self.moment(2))
 
+    def get_default(self):
+        """Return the default data group if it is defined or None.
+        
+        Returns
+        -------
+        NXdata
+            Data group to be plotted.
+        """
+        if 'default' in self.attrs and self.attrs['default'] in self:
+            default = self[self.attrs['default']]
+            return default.get_default()
+        else:
+            return None
+
+    def set_default(self):
+        """Set the current group as the default for plotting.
+        
+        This function is overridden by the NXentry and NXdata classes. For all
+        other groups, it raises an error.
+        """
+        raise NeXusError(
+            "Can only set the default for NXentry and NXdata groups")
+
     def is_plottable(self):
         """Return True if the group contains plottable data."""
         plottable = False
@@ -5296,15 +5319,10 @@ class NXroot(NXgroup):
         NXdata
             Data group to be plotted.
         """
-        if 'default' in self.attrs and self.attrs['default'] in self:
-            group = self[self.attrs['default']]
-            if isinstance(group, NXdata):
-                return group
-            elif isinstance(group, NXentry):
-                plottable_data = group.plottable_data
-                if isinstance(plottable_data, NXdata):
-                    return plottable_data
-        if self.NXdata:
+        default = self.get_default()
+        if default is not None:
+            return default
+        elif self.NXdata:
             return self.NXdata[0]
         elif self.NXmonitor:
             return self.NXmonitor[0]
@@ -5424,6 +5442,27 @@ class NXentry(NXgroup):
         except KeyError:
             raise NeXusError("Inconsistency between two NXentry groups")
 
+    def set_default(self, over=False):
+        """Set group as the default for plotting.
+        
+        This will set defaults for parents of the parent group unless they have
+        been set previously.
+        """
+        group = self.nxgroup
+        if group is None:
+            raise NeXusError(
+                "The default cannot be defined without a parent group")
+        elif isinstance(group, NXentry) or isinstance(group, NXroot):
+            group.attrs['default'] = self.nxname
+            parent_group = group.nxgroup
+            parent_group = group.nxgroup
+            if parent_group:
+                if over or parent_group.get_default() is None:
+                    group.set_default(over=over)
+        else:
+            raise NeXusError(
+                "The default can only be defined in a NXentry or NXroot group")
+
     @property
     def plottable_data(self):
         """The default data group to be plotted in this entry.
@@ -5431,17 +5470,11 @@ class NXentry(NXgroup):
         This will return the default group if the `default` attribute has been
         set. Otherwise, the first NXdata, NXmonitor, or NXlog group will be 
         returned.
-        
-        Returns
-        -------
-        NXdata
-            Data group to be plotted.
         """
-        if 'default' in self.attrs and self.attrs['default'] in self:
-            plottable_data = self[self.attrs['default']]
-            if isinstance(plottable_data, NXdata):
-                return plottable_data
-        if self.NXdata:
+        default = self.get_default()
+        if default is not None:
+            return default
+        elif self.NXdata:
             return self.NXdata[0]
         elif self.NXmonitor:
             return self.NXmonitor[0]
@@ -6055,6 +6088,32 @@ class NXdata(NXgroup):
                     ind = slice(ind.start, ind.stop+1, ind.step)
                 axes[i] = axes[i][ind]
         return tuple(slices), axes
+
+    def get_default(self):
+        """Return this NXdata group as the default for plotting."""
+        return self
+
+    def set_default(self, over=False):
+        """Set group as the default for plotting.
+        
+        Parameters
+        ==========
+        over : bool
+            True if previous defa
+        """
+        group = self.nxgroup
+        if group is None:
+            raise NeXusError(
+                "The default cannot be defined without a parent group")
+        elif isinstance(group, NXentry) or isinstance(group, NXroot):
+            group.attrs['default'] = self.nxname
+            parent_group = group.nxgroup
+            if parent_group:
+                if over or parent_group.get_default() is None:
+                    group.set_default(over=over)
+        else:
+            raise NeXusError(
+                "The default can only be defined in a NXentry or NXroot group")
 
     @property
     def plottable_data(self):

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -31,6 +31,32 @@ def test_data_creation():
     assert data.nxtitle == "Title"
 
 
+def test_default_data():
+
+    data = NXdata(v, (z, y, x), title="Title")
+    root = NXroot(NXentry(data))
+    root["entry/data"].set_default()
+
+    assert root.get_default() is root["entry/data"]
+    assert root["entry"].get_default() is root["entry/data"]
+    assert root["entry/data"].get_default() is root["entry/data"]
+    assert root.plottable_data is root["entry/data"]
+
+    root["entry/subentry"] = NXsubentry(data)
+    root["entry/subentry/data"].set_default()
+
+    assert root.get_default() is root["entry/data"]
+    assert root["entry/subentry"].get_default() is root["entry/subentry/data"]
+    assert root["entry/subentry"].plottable_data is root["entry/subentry/data"]
+
+    root["entry/subentry/data"].set_default(over=True)
+
+    assert root.get_default() is root["entry/subentry/data"]
+    assert root["entry"].get_default() is root["entry/subentry/data"]
+    assert root["entry/data"].get_default() is root["entry/data"]
+    assert root.plottable_data is root["entry/subentry/data"]
+
+
 def test_plottable_data():
 
     data = NXdata(v, (z, y, x), title="Title")


### PR DESCRIPTION
* Adds new `get_default` and `set_default` functions to handle the definition of default plots.
* Defaults are automatically propagated up the NeXus tree if they had not been previously defined. Use the keyword argument `over=True` in the `set_default` function to override previous settings.