### PR TITLE
Fix scalar output of masked arrays

### DIFF
--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -2795,7 +2795,7 @@ class NXfield(NXobject):
                     s = s[:s.index('\n')]+'...'
                 except ValueError:
                     pass
-                if len(self) == 1:
+                if self.size == 1:
                     s = "'" + s + "'"
             elif len(self) > 3 or '\n' in s or s == "":
                 if self.shape is None:

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -2729,8 +2729,10 @@ class NXfield(NXobject):
             else:
                 raise NeXusError(
                     "Data not available either in file or in memory")
+        elif np.ma.is_masked(self._value):
+            result = np.ma.asarray(self._value[idx])
         else:
-            result = np.asarray(self.nxdata[idx])
+            result = np.asarray(self._value[idx])
         return NXfield(result, name=self.nxname, attrs=self.safe_attrs)
 
     def __setitem__(self, idx, value):

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -1429,7 +1429,7 @@ def _getvalue(value, dtype=None, shape=None):
             _value = _value.reshape(shape)
         except ValueError:
             raise NeXusError("The value is incompatible with the shape")
-    if _value.shape == ():
+    if _value.shape == () and not np.ma.is_masked(_value):
         return _value.item(), _value.dtype, _value.shape
     else:
         return _value, _value.dtype, _value.shape
@@ -2729,10 +2729,12 @@ class NXfield(NXobject):
             else:
                 raise NeXusError(
                     "Data not available either in file or in memory")
-        elif np.ma.is_masked(self._value):
-            result = np.ma.asarray(self._value[idx])
+            if self.mask is not None:
+                result = np.ma.MaskedArray.__getitem__(result, ())
+        elif self.mask is not None:
+            result = np.ma.MaskedArray.__getitem__(self.nxdata, idx)
         else:
-            result = np.asarray(self._value[idx])
+            result = np.asarray(self.nxdata[idx])
         return NXfield(result, name=self.nxname, attrs=self.safe_attrs)
 
     def __setitem__(self, idx, value):

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -1,4 +1,3 @@
-import h5py as h5
 import numpy as np
 import os
 import pytest

--- a/tests/test_masks.py
+++ b/tests/test_masks.py
@@ -13,11 +13,15 @@ def test_field_masks():
     assert isinstance(field.nxvalue, np.ma.masked_array)
     assert np.all(field[8:12].mask == np.array([False, False, True, True]))
     assert np.all(field.mask[8:12] == np.array([False, False, True, True]))
+    assert np.ma.is_masked(field[8:12].nxvalue)
     assert np.ma.is_masked(field.nxvalue[10])
+    assert np.ma.is_masked(field[10].nxvalue)
+    assert field[10].mask
 
     field.mask[10] = np.ma.nomask
 
     assert np.all(field.mask[8:12] == np.array([False, False, False, True]))
+    assert not field[10].mask
 
 
 @pytest.mark.parametrize("save", ["False", "True"])

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -1,7 +1,6 @@
 import pytest
 from nexusformat.nexus import *
 
-
 field1 = NXfield((1,2), name="f1")
 
 


### PR DESCRIPTION
* Ensures that the return value is masked when an index references a single value in a masked NXfield.
* Fixes a bug returning a regular array when referencing a slab.
* Adds unit tests for masked NXfields.
* Improves the formatting of float values in a printed tree.