### PR TITLE
Lazy loading of NeXus files

### DIFF
--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -382,7 +382,7 @@ class NXFile(object):
     the file closed again. 
     """
 
-    def __init__(self, name, mode='r', **kwargs):
+    def __init__(self, name, mode='r', recursive=True, **kwargs):
         """Open an HDF5 file for reading and writing NeXus files.
 
         This creates a h5py File instance that is used for all subsequent
@@ -397,11 +397,15 @@ class NXFile(object):
         ----------
         name : str
             Name of the HDF5 file.
-        mode : {'r', 'rw', 'r+', 'w', 'w-', 'a'}
+        mode : {'r', 'rw', 'r+', 'w', 'w-', 'a'}, optional
             Read/write mode of the HDF5 file, by default 'r'. These all have 
             the same meaning as their h5py counterparts, apart from 'rw', 
             which is equivelent to 'r+'. After creating and/or opening the 
             file, the mode is set to 'r' or 'rw' for remaining operations.
+        recursive : bool, optional
+            If True, the file tree is loaded recursively, by default True. 
+            If False, only the entries in the root group are read. Other group 
+            entries will be read automatically when they are referenced.
         **kwargs
             Keyword arguments to be used when opening the h5py File object.
         """
@@ -413,6 +417,7 @@ class NXFile(object):
         self._path = '/'
         self._root = None
         self._with_count = 0
+        self.recursive = recursive
         if mode == 'w4' or mode == 'wx':
             raise NeXusError("Only HDF5 files supported")
         elif not os.path.exists(os.path.dirname(self._filename)):
@@ -708,7 +713,7 @@ class NXFile(object):
         for name, value in items:
             self.nxpath = self.nxpath + '/' + name
             if isinstance(value, self.h5.Group):
-                children[name] = self._readgroup(name)
+                children[name] = self._readgroup(name, recursive=self.recursive)
             elif isinstance(value, self.h5.Dataset):
                 children[name] = self._readdata(name)
             else:
@@ -718,13 +723,16 @@ class NXFile(object):
             self.nxpath = self.nxparent
         return children
 
-    def _readgroup(self, name):
+    def _readgroup(self, name, recursive=True):
         """Return the group at the current path.
         
         Parameters
         ----------
         name : str
             Name of the group.
+        recursive : bool, optional
+            If True, the group children will be loaded into the group 
+            dictionary, by default True.
         
         Returns
         -------
@@ -735,16 +743,18 @@ class NXFile(object):
         nxclass = self._getclass(attrs.pop('NX_class', 'NXgroup'))
         if nxclass == 'NXgroup' and self.nxpath == '/':
             nxclass = 'NXroot'
-        children = self._readchildren()
         _target, _filename, _abspath = self._getlink()
         if _target is not None:
             group = NXlinkgroup(nxclass=nxclass, name=name, target=_target,
                                 file=_filename, abspath=_abspath)
         else:
             group = NXgroup(nxclass=nxclass, name=name, attrs=attrs)
-        for child in children:
-            group._entries[child] = children[child]
-            children[child]._group = group
+        if recursive:
+            children = self._readchildren()
+            group._entries = {}
+            for child in children:
+                group._entries[child] = children[child]
+                children[child]._group = group
         group._changed = True
         return group
 
@@ -1053,6 +1063,27 @@ class NXFile(object):
             return self._readgroup(self.nxname)
         else:
             return self._readdata(self.nxname)
+
+    def readentries(self, group):
+        """Return the group entries from the file.
+        
+        Parameters
+        ----------
+        group : NXgroup
+            The group whose entries are to be loaded.
+        
+        Returns
+        -------
+        dict
+            A dictionary of all the group entries.
+        """
+        self.nxpath = group.nxpath
+        children = self._readchildren()
+        _entries = {}
+        for child in children:
+            _entries[child] = children[child]
+            _entries[child]._group = group
+        return _entries
 
     def readvalues(self, attrs=None):
         """Read the values of the field at the current path.
@@ -4113,7 +4144,6 @@ class NXgroup(NXobject):
     _class = 'NXgroup'
 
     def __init__(self, *args, **kwargs):
-        self._entries = {}
         if "name" in kwargs:
             self._name = kwargs.pop("name")
         if "nxclass" in kwargs:
@@ -4121,9 +4151,12 @@ class NXgroup(NXobject):
         if "group" in kwargs:
             self._group = kwargs.pop("group")
         if "entries" in kwargs:
+            self._entries = {}
             for k,v in kwargs["entries"].items():
                 self._entries[k] = deepcopy(v)
             del kwargs["entries"]
+        else:
+            self._entries = None
         if "attrs" in kwargs:
             self._attrs = AttrDict(self, attrs=kwargs["attrs"])
             del kwargs["attrs"]
@@ -4874,13 +4907,30 @@ class NXgroup(NXobject):
     def entries(self):
         """Dictionary of NeXus objects in the group.
         
+        If the NeXus data is stored in a file that was loaded with the 
+        'recursive' keyword set to False, only the root entries will have been
+        read. This property automatically reads any missing entries as they are
+        referenced.
+        
         Returns
         -------
         dict of NXfields and/or NXgroups
             Dictionary of group objects.
         """
+        if self._entries is None:
+            if self.nxfile:
+                with self.nxfile as f:
+                    self._entries = f.readentries(self)
+            else:
+                self._entries = {}
+            self.set_changed()
         return self._entries
 
+    @property
+    def entries_loaded(self):
+        """True if the NXgroup entriees have been initialized."""
+        return self._entries is not None
+    
     nxsignal = None
     nxaxes = None
     nxerrors = None
@@ -6639,7 +6689,7 @@ nxgetmaxsize = getmaxsize
 nxsetmaxsize = setmaxsize
 
 # File level operations
-def load(filename, mode='r', **kwargs):
+def load(filename, mode='r', recursive=True, **kwargs):
     """Open or create a NeXus file and load its tree.
     
     Notes
@@ -6653,13 +6703,17 @@ def load(filename, mode='r', **kwargs):
         Name of the file to be opened or created.
     mode : {'r', 'rw', 'r+', 'w', 'a'}, optional
         File mode, by default 'r'
+    recursive : bool, optional
+        If True, the file tree is loaded recursively, by default True. 
+        If False, only the entries in the root group are read. Other group 
+        entries will be read automatically when they are referenced.
     
     Returns
     -------
     NXroot
         NXroot object containing the NeXus tree.
     """
-    with NXFile(filename, mode, **kwargs) as f:
+    with NXFile(filename, mode, recursive=recursive, **kwargs) as f:
         root = f.readfile()
     return root
 

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -2047,9 +2047,10 @@ class NXobject(object):
                 signal = True
             else:
                 axes = group.nxaxes
-                axis_names = [axis.nxname for axis in axes]
-                if self.nxname in axis_names:
-                    axis = axis_names.index(self.nxname)
+                if axes is not None:
+                    axis_names = [axis.nxname for axis in axes]
+                    if self.nxname in axis_names:
+                        axis = axis_names.index(self.nxname)
         elif self.nxfilemode == 'r':
             raise NeXusError("NeXus file opened as readonly")
         self._name = name

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -5180,7 +5180,6 @@ class NXlinkgroup(NXlink, NXgroup):
             self._setclass(_getclass(kwargs['nxclass'], link=True))
         else:
             self._class = 'NXlink'
-        self._entries = {}
 
     def __getattr__(self, name):
         """Return attribute looking in the group entries and attributes.

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -1246,7 +1246,7 @@ class NXFile(object):
                         group = self._root
                     else:
                         group = self._root[self.nxparent]
-                    group._entries[item.nxname] = item
+                    group.entries[item.nxname] = item
                     group[item.nxname]._group = group
             self.nxpath = item.nxpath
 

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -4958,6 +4958,7 @@ class NXlink(NXobject):
         self._name = name
         self._group = group
         self._abspath = abspath
+        self._entries = None
         if file is not None:
             self._filename = file
             self._mode = 'r'
@@ -5224,6 +5225,9 @@ class NXlinkgroup(NXlink, NXgroup):
             for entry in _linked_entries:
                 _entries[entry] = deepcopy(_linked_entries[entry])
                 _entries[entry]._group = self
+        if _entries != self._entries:
+            self._entries = _entries
+            self.set_changed()
         return _entries
 
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -90,6 +90,20 @@ def test_signal_selection():
     assert [axis.nxname for axis in data.nxaxes] == ["z", "y", "x"]
 
 
+def test_rename():
+
+    data = NXdata()
+    data.nxsignal = v
+    data.nxaxes = (z, y, x)
+
+    data["x"].rename("xx")
+    data["y"].rename("yy")
+    data["z"].rename("zz")
+    data["v"].rename("vv")
+    assert data.nxsignal.nxname == "vv"
+    assert [axis.nxname for axis in data.nxaxes] == ["zz", "yy", "xx"]
+
+
 def test_size_one_axis():
 
     y1 = np.array((1), dtype=np.float64)
@@ -195,33 +209,33 @@ def test_data_projections():
 
     d1 = NXdata(v[0], (y, x))
 
-    assert d1.nxaxes == [d1['y'], d1['x']]
+    assert d1.nxaxes == [d1["y"], d1["x"]]
 
     p1 = d1.project((1, 0))
     p2 = d1.project((0, 1), limits=((3., 9.), (4., 16.)))
 
-    assert p1.nxaxes == [p1['x'], p1['y']]
-    assert np.array_equal(p1['x'].nxvalue, d1['x'])
-    assert p2.nxaxes == [p2['y'], p2['x']]
-    assert np.array_equal(p2['x'].nxvalue, d1['x'][4.:16.])
-    assert np.array_equal(p2['x'].nxvalue, d1['x'][2:9])
+    assert p1.nxaxes == [p1["x"], p1["y"]]
+    assert np.array_equal(p1["x"].nxvalue, d1["x"])
+    assert p2.nxaxes == [p2["y"], p2["x"]]
+    assert np.array_equal(p2["x"].nxvalue, d1["x"][4.:16.])
+    assert np.array_equal(p2["x"].nxvalue, d1["x"][2:9])
 
     d2 = NXdata(v, (z, y, x))
 
     p3 = d2.project((0,1),((0.,8.),(3.,9.),(4.,16.)))
 
-    assert p3.nxaxes == [p3['z'], p3['y']]
-    assert np.array_equal(p3['y'].nxvalue, d2['y'][3.:9.])
-    assert np.array_equal(p3['y'].nxvalue, d2['y'][1:4])
-    assert p3['x'] == 10.
-    assert p3['x'].attrs['minimum'] == 4.
-    assert p3['x'].attrs['maximum'] == 16.
-    assert p3['x'].attrs['summed_bins'] == 7
-    assert p3['v'].sum() == d2.v[:,1:3,2:8].sum()
+    assert p3.nxaxes == [p3["z"], p3["y"]]
+    assert np.array_equal(p3["y"].nxvalue, d2["y"][3.:9.])
+    assert np.array_equal(p3["y"].nxvalue, d2["y"][1:4])
+    assert p3["x"] == 10.
+    assert p3["x"].attrs["minimum"] == 4.
+    assert p3["x"].attrs["maximum"] == 16.
+    assert p3["x"].attrs["summed_bins"] == 7
+    assert p3["v"].sum() == d2.v[:,1:3,2:8].sum()
     
     p4 = d2.project((0,1),((0.,8.),(3.,9.),(4.,16.)), summed=False)
 
-    assert p4['v'].sum() == d2.v[:,1:3,2:8].sum() / p4['x'].attrs['summed_bins']
+    assert p4["v"].sum() == d2.v[:,1:3,2:8].sum() / p4["x"].attrs["summed_bins"]
 
 
 def test_data_smoothing():
@@ -239,14 +253,14 @@ def test_data_smoothing():
 def test_image_data():
 
     root = NXroot(NXentry(NXdata(im)))
-    root['entry'].attrs['default'] = 'data'
-    root['entry/other_data'] = NXdata(v, (z, y, x), title="Title")
+    root["entry"].attrs["default"] = "data"
+    root["entry/other_data"] = NXdata(v, (z, y, x), title="Title")
 
-    assert root['entry/data/image'].is_image()
-    assert root['entry/data'].is_image()
+    assert root["entry/data/image"].is_image()
+    assert root["entry/data"].is_image()
     assert root.plottable_data.is_image()
-    assert root['entry'].plottable_data.is_image()
-    assert not root['entry/other_data'].is_image()
+    assert root["entry"].plottable_data.is_image()
+    assert not root["entry/other_data"].is_image()
 
 
 def test_smart_indices():

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -38,3 +38,30 @@ def test_file_save(tmpdir):
     assert 'entry/data/f2' in w2
     assert 'signal' in w2['entry/data'].attrs
     assert 'axes' in w2['entry/data'].attrs
+
+
+@pytest.mark.parametrize("recursive", ["True", "False"])
+def test_file_recursion(tmpdir, recursive):
+
+    filename = os.path.join(tmpdir, 'file.nxs')
+    w1 = NXroot(NXentry())
+    w1.entry.data = NXdata(field1, field2)
+    w1.save(filename)
+
+    w2 = nxload(filename, recursive=recursive)
+
+    if not recursive:
+        assert w2['entry']._entries is None
+        assert 'entry/data' in w2
+        assert w2['entry']._entries is not None
+        assert w2['entry/data']._entries is None
+        assert 'entry/data/f1' in w2
+        assert w2['entry/data']._entries is not None
+        assert w2['entry/data/f2'] == field2
+
+    assert 'entry/data/f1' in w2
+    assert 'entry/data/f2' in w2
+    assert 'signal' in w2['entry/data'].attrs
+    assert 'axes' in w2['entry/data'].attrs
+        
+

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -11,16 +11,16 @@ field3 = NXfield((5,6), name="f3")
 
 def test_file_creation(tmpdir):
 
-    filename = os.path.join(tmpdir, 'file.nxs')
-    with NXFile(filename, 'w') as f:
-        assert f.mode == 'rw'
+    filename = os.path.join(tmpdir, "file.nxs")
+    with NXFile(filename, "w") as f:
+        assert f.mode == "rw"
         assert f.filename == filename
     assert not f.is_open()
 
 
 def test_file_save(tmpdir):
 
-    filename = os.path.join(tmpdir, 'file.nxs')
+    filename = os.path.join(tmpdir, "file.nxs")
 
     w1 = NXroot(NXentry())
     w1.entry.data = NXdata(field1, field2)
@@ -29,21 +29,21 @@ def test_file_save(tmpdir):
     assert os.path.exists(filename)
     assert not w1.nxfile.is_open()
     assert w1.nxfilename == filename
-    assert w1.nxfilemode == 'rw'
+    assert w1.nxfilemode == "rw"
 
     w2 = nxload(filename)
     assert w2.nxfilename == filename
-    assert w2.nxfilemode == 'r'
-    assert 'entry/data/f1' in w2
-    assert 'entry/data/f2' in w2
-    assert 'signal' in w2['entry/data'].attrs
-    assert 'axes' in w2['entry/data'].attrs
+    assert w2.nxfilemode == "r"
+    assert "entry/data/f1" in w2
+    assert "entry/data/f2" in w2
+    assert "signal" in w2["entry/data"].attrs
+    assert "axes" in w2["entry/data"].attrs
 
 
 @pytest.mark.parametrize("recursive", ["True", "False"])
 def test_file_recursion(tmpdir, recursive):
 
-    filename = os.path.join(tmpdir, 'file.nxs')
+    filename = os.path.join(tmpdir, "file.nxs")
     w1 = NXroot(NXentry())
     w1.entry.data = NXdata(field1, field2)
     w1.save(filename)
@@ -51,17 +51,17 @@ def test_file_recursion(tmpdir, recursive):
     w2 = nxload(filename, recursive=recursive)
 
     if not recursive:
-        assert w2['entry']._entries is None
-        assert 'entry/data' in w2
-        assert w2['entry']._entries is not None
-        assert w2['entry/data']._entries is None
-        assert 'entry/data/f1' in w2
-        assert w2['entry/data']._entries is not None
-        assert w2['entry/data/f2'] == field2
+        assert w2["entry"]._entries is None
+        assert "entry/data" in w2
+        assert w2["entry"]._entries is not None
+        assert w2["entry/data"]._entries is None
+        assert "entry/data/f1" in w2
+        assert w2["entry/data"]._entries is not None
+        assert w2["entry/data/f2"] == field2
 
-    assert 'entry/data/f1' in w2
-    assert 'entry/data/f2' in w2
-    assert 'signal' in w2['entry/data'].attrs
-    assert 'axes' in w2['entry/data'].attrs
+    assert "entry/data/f1" in w2
+    assert "entry/data/f2" in w2
+    assert "signal" in w2["entry/data"].attrs
+    assert "axes" in w2["entry/data"].attrs
         
 

--- a/tests/test_groups.py
+++ b/tests/test_groups.py
@@ -55,6 +55,18 @@ def test_group_insertion():
     assert len(group1) == 1
 
 
+def test_rename():
+
+    group = NXgroup(field1)
+
+    assert "f1" in group
+
+    group["f1"].rename("f2")
+
+    assert "f1" not in group
+    assert "f2" in group
+
+
 def test_entry_creation():
 
     group = NXentry()

--- a/tests/test_locks.py
+++ b/tests/test_locks.py
@@ -2,8 +2,9 @@ import os
 import pytest
 import time
 from nexusformat.nexus import *
+from nexusformat.nexus.tree import text
 
-field1 = NXfield('a', name="f1")
+field1 = NXfield("a", name="f1")
 
 
 def test_lock_creation(tmpdir):
@@ -131,13 +132,13 @@ def test_nested_locks(tmpdir):
 
         root["entry/f1"] = "b"
 
-        assert root.nxfile["entry/f1"][()] == "b"
+        assert text(root.nxfile["entry/f1"][()]) == "b"
 
         with root.nxfile:
 
             root["entry/f1"] = "c"
 
-            assert root.nxfile["entry/f1"][()] == "c"
+            assert text(root.nxfile["entry/f1"][()]) == "c"
             assert root.nxfile.locked
             assert root.nxfile.is_locked()
 


### PR DESCRIPTION
* Adds a 'recursive' boolean keyword to the NXFile initialization and the nxload function that determines whether the whole file is loaded recursively or just the root level entries. If set to False, groups and fields that are below this level are only loaded when referenced. This speeds up file loading, particularly for files with many objects, at the expense of some latency in other read operations.
* Fixes a bug when renaming NeXus objects, while adding unit tests for such operations.
* Fixes an incompatibility with the upcoming h5py v3.0 release that causes a unit test failure. Other functionality is not affected by the changes in the h5py library.