### PR TITLE
Use consistent capitalization for NumPy

### DIFF
--- a/src/nexusformat/notebooks/nexusformat.ipynb
+++ b/src/nexusformat/notebooks/nexusformat.ipynb
@@ -82,7 +82,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In this case, the `NXfield` object contains the Numpy array, and can be manipulated using standard Numpy operations."
+    "In this case, the `NXfield` object contains the NumPy array, and can be manipulated using standard NumPy operations."
    ]
   },
   {
@@ -116,7 +116,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Like Numpy arrays, NeXus fields have datatypes and shape, which can be manipulated using standard Numpy operations."
+    "Like NumPy arrays, NeXus fields have datatypes and shape, which can be manipulated using standard NumPy operations."
    ]
   },
   {
@@ -159,7 +159,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "NeXus fields can contain scalars and arrays of any Numpy data type, as well as text, which is stored in NeXus files as variable-length strings, by default."
+    "NeXus fields can contain scalars and arrays of any NumPy data type, as well as text, which is stored in NeXus files as variable-length strings, by default."
    ]
   },
   {
@@ -233,7 +233,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "> *N.B.* Dictionary assignments are safer when there are potential name clashes with, *e.g.*, Numpy attributes, and should be used when writing scripts. However, attribute assignments are allowed as a convenience as they are quicker to type in interactive sessions.\n",
+    "> *N.B.* Dictionary assignments are safer when there are potential name clashes with, *e.g.*, NumPy attributes, and should be used when writing scripts. However, attribute assignments are allowed as a convenience as they are quicker to type in interactive sessions.\n",
     "\n",
     "Since group entries are defined in a dictionary, the usual dictionary operations are available."
    ]
@@ -423,7 +423,7 @@
    "metadata": {},
    "source": [
     "### Slicing NXdata Groups\n",
-    "The NXdata groups can be sliced as though they were a Numpy array, since they contain one signal array."
+    "The NXdata groups can be sliced as though they were a NumPy array, since they contain one signal array."
    ]
   },
   {
@@ -458,7 +458,7 @@
    "metadata": {},
    "source": [
     "### Manipulating NXdata Groups\n",
-    "The NXdata groups can be used in arithmetic expressions involving addition, subtraction, multiplication, and division, using the same broadcast rules as Numpy arrays."
+    "The NXdata groups can be used in arithmetic expressions involving addition, subtraction, multiplication, and division, using the same broadcast rules as NumPy arrays."
    ]
   },
   {


### PR DESCRIPTION
* Updates the Jupyter notebook to make NumPy capitalization consistent with accepted use.