### PR TITLE
Use NumPy to determine byte-string dtype

### DIFF
--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -1432,8 +1432,10 @@ def _getvalue(value, dtype=None, shape=None):
             try:
                 _dtype = _getdtype(dtype)
                 if _dtype.kind == 'S':
-                    value = text(value).encode('utf-8')
-                return np.array(value, dtype=_dtype).item(), _dtype, ()
+                    value = np.array(text(value).encode('utf-8'), dtype=_dtype)
+                else:
+                    value = np.array(value, dtype=_dtype)
+                return value.item(), value.dtype, ()
             except Exception:
                 raise NeXusError("The value is incompatible with the dtype")
         else:


### PR DESCRIPTION
* Fixes an issue where h5py raises an exception if an NXfield is initialized with a byte-string dtype of kind 'S' without specifying its length. 