### PR TITLE
Improve external link behavior

### DIFF
--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -2369,7 +2369,7 @@ class NXobject(object):
         """
         if self.nxclass == 'NXroot':
             return "/"
-        elif isinstance(self, NXlink):
+        elif self.nxtarget:
             return self.nxtarget
         elif self.nxgroup is None:
             return ""
@@ -5184,6 +5184,9 @@ class NXlink(NXobject):
         try:
             with self.nxfile as f:
                 item = f.readpath(self.nxfilepath)
+            item._target = self.nxfilepath
+            item._filename = self.nxfilename
+            item._mode = 'r'
             return item
         except Exception as error:
             raise NeXusError("Cannot read the external link to '%s'" 
@@ -5226,6 +5229,9 @@ class NXlinkfield(NXlink, NXfield):
         NXlink.__init__(self, target=target, file=file, name=name, 
                         abspath=abspath, soft=soft)
         self._class = 'NXfield'
+
+    def __getitem__(self, key):
+        return self.nxlink.__getitem__(key)
 
     @property
     def nxdata(self):

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -2773,7 +2773,7 @@ class NXfield(NXobject):
         Parameters
         ----------
         idx : slice
-            Slice indices.
+            Slice index or indices.
         
         Returns
         -------
@@ -5177,10 +5177,12 @@ class NXlink(NXobject):
 
     @property
     def internal_link(self):
+        """Return NXfield or NXgroup targeted by an internal link."""
         return self.nxroot[self._target]
 
     @property
     def external_link(self):
+        """Return NXfield or NXgroup targeted by an external link."""
         try:
             with self.nxfile as f:
                 item = f.readpath(self.nxfilepath)
@@ -5194,6 +5196,7 @@ class NXlink(NXobject):
 
     @property
     def attrs(self):
+        """Return attributes of the linked NXfield or NXgroup."""
         try:
             return self.nxlink.attrs
         except NeXusError:
@@ -5230,11 +5233,24 @@ class NXlinkfield(NXlink, NXfield):
                         abspath=abspath, soft=soft)
         self._class = 'NXfield'
 
-    def __getitem__(self, key):
-        return self.nxlink.__getitem__(key)
+    def __getitem__(self, idx):
+        """Return the slab of the linked field defined by the index.
+        
+        Parameters
+        ----------
+        idx : slice
+            Slice index or indices.
+        
+        Returns
+        -------
+        NXfield
+            Field containing the slice values.
+        """
+        return self.nxlink.__getitem__(idx)
 
     @property
     def nxdata(self):
+        """Data of linked NXfield."""
         return self.nxlink.nxdata
 
 

--- a/tests/test_links.py
+++ b/tests/test_links.py
@@ -141,11 +141,14 @@ def test_embedded_links(tmpdir, save):
     assert "f2" not in root["entry/g2_link/g3"]
 
 
-def test_external_field_links(tmpdir):
+@pytest.mark.parametrize("save", ["False", "True"])
+def test_external_field_links(tmpdir, save):
 
-    filename = os.path.join(tmpdir, "file1.nxs")
     root = NXroot(NXentry())
-    root.save(filename, mode="w")
+
+    if save:
+        filename = os.path.join(tmpdir, "file1.nxs")
+        root.save(filename, mode="w")
 
     external_filename = os.path.join(tmpdir, "file2.nxs")
     external_root = NXroot(NXentry(field1))
@@ -167,11 +170,14 @@ def test_external_field_links(tmpdir):
     assert "units" in root["entry/f1_link"].attrs
 
 
-def test_external_group_links(tmpdir):
+@pytest.mark.parametrize("save", ["False", "True"])
+def test_external_group_links(tmpdir, save):
 
-    filename = os.path.join(tmpdir, "file1.nxs")
     root = NXroot(NXentry())
-    root.save(filename, mode="w")
+
+    if save:
+        filename = os.path.join(tmpdir, "file1.nxs")
+        root.save(filename, mode="w")
 
     external_filename = os.path.join(tmpdir, "file2.nxs")
     external_root = NXroot(NXentry(NXgroup(field1, name='g1', attrs={"a":"b"})))


### PR DESCRIPTION
* Enables the reading of externally linked NXfields when the parent tree has not been saved to a file.
* Updates the pytest modules to reflect the change.