### PR TITLE
Restore the name of an externally linked field

### DIFF
--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -5251,7 +5251,10 @@ class NXlinkfield(NXlink, NXfield):
         NXfield
             Field containing the slice values.
         """
-        return self.nxlink.__getitem__(idx)
+        result = self.nxlink.__getitem__(idx)
+        if isinstance(result, NXfield):
+            result._name = self._name
+        return result
 
     @property
     def nxdata(self):


### PR DESCRIPTION
This fixes a bug, in which a field slab from data stored in an external file is returned with the name set to the name in the external file. It ensures that the slab has the same name as the field in the parent file.