### PR TITLE
Customize `is_external` function for NXlinks

### DIFF
--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -5205,6 +5205,12 @@ class NXlink(NXobject):
             raise NeXusError("Cannot read the external link to '%s'" 
                              % self._filename)
 
+    def is_external(self):
+        if self.nxroot is self and self._filename:
+            return True
+        else:
+            return super(NXlink, self).is_external()
+
     @property
     def attrs(self):
         """Return attributes of the linked NXfield or NXgroup."""


### PR DESCRIPTION
* Specifies a NXlink as external if it has an assigned filename and has not been assigned to another group.