### PR TITLE
Refactor tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,3 @@ numpy
 scipy
 ipython
 pytest
-pytest-lazy-fixture

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ h5py
 numpy
 scipy
 ipython
+pytest
+pytest-lazy-fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,38 @@
+"""
+Pytest automatically parses this module for fixtures that can be used in its
+directory, as well as in any of its subdirectories.
+
+This module contains fixtures that return generic NXfields.
+"""
+
+from pytest import fixture
+import numpy as np
+
+from nexusformat.nexus.tree import NXfield, NXdata
+
+
+@fixture
+def x():
+    return NXfield(2 * np.linspace(0.0, 10.0, 11, dtype=np.float64), name="x")
+
+
+@fixture
+def y():
+    return NXfield(3 * np.linspace(0.0, 5.0, 6, dtype=np.float64), name="y")
+
+
+@fixture
+def z():
+    return NXfield(4 * np.linspace(0.0, 2.0, 3, dtype=np.float64), name="z")
+
+
+@fixture
+def v():
+    v = NXfield(np.linspace(0, 99, num=100, dtype=np.float64), name="v")
+    v.resize((2, 5, 10))
+    return v
+
+
+@fixture
+def im():
+    return NXfield(np.ones(shape=(10, 10, 4), dtype=np.float32), name='image')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,22 +8,32 @@ This module contains fixtures that return generic NXfields.
 from pytest import fixture
 import numpy as np
 
-from nexusformat.nexus.tree import NXfield, NXdata
+from nexusformat.nexus.tree import NXfield
 
 
 @fixture
-def x():
-    return NXfield(2 * np.linspace(0.0, 10.0, 11, dtype=np.float64), name="x")
+def x(): return NXfield(2*np.linspace(0.0, 10, 11, dtype=np.float64), name="x")
+@fixture
+def y(): return NXfield(3*np.linspace(0.0, 5.0, 6, dtype=np.float64), name="y")
+@fixture
+def z(): return NXfield(4*np.linspace(0.0, 2.0, 3, dtype=np.float64), name="z")
+@fixture
+def field1(): return NXfield((1, 2), name="f1")
+@fixture
+def field2(): return NXfield((3, 4), name="f2")
+@fixture
+def field3(): return NXfield((5, 6), name="f3")
+@fixture
+def field4(): return NXfield("a", name="f1")
+@fixture
+def arr1D(): return np.linspace(0.0, 100.0, 101, dtype=np.float64)
+@fixture
+def arr2D(): return np.array(((1, 2, 3, 4), (5, 6, 7, 8)), dtype=np.int32)
 
 
 @fixture
-def y():
-    return NXfield(3 * np.linspace(0.0, 5.0, 6, dtype=np.float64), name="y")
-
-
-@fixture
-def z():
-    return NXfield(4 * np.linspace(0.0, 2.0, 3, dtype=np.float64), name="z")
+def arr3D(): return np.resize(np.linspace(
+    0.0, 124.0, 125, dtype=np.float64), (5, 5, 5))
 
 
 @fixture

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,24 +1,58 @@
 import numpy as np
+from nexusformat.nexus.tree import NXfield, NXdata, NXroot, NXentry, NXsubentry
 import pytest
 import warnings
-from nexusformat.nexus import *
-
-x = NXfield(2 * np.linspace(0.0, 10.0, 11, dtype=np.float64), name="x")
-y = NXfield(3 * np.linspace(0.0, 5.0, 6, dtype=np.float64), name="y")
-z = NXfield(4 * np.linspace(0.0, 2.0, 3, dtype=np.float64), name="z")
-v = NXfield(np.linspace(0, 99, num=100, dtype=np.float64), name="v")
-v.resize((2, 5, 10))
-im = NXfield(np.ones(shape=(10, 10, 4), dtype=np.float32), name='image')
 
 
-def test_data_creation():
+@pytest.fixture
+def data(x, y, z, v):
+    """
+    Returns a simple NXdata object with a title.
+    """
+    return NXdata(v, (z, y, x), title="Title")
 
-    data = NXdata(v, (z, y, x), title="Title")
-    
+
+@pytest.fixture
+def data2(v):
+    """
+    Returns a different, simple NXdata object with a title.
+    """
+    v2 = v[0]
+    v2.resize((1, 5, 10))
+    return NXdata(v2)
+
+
+@pytest.fixture
+def empty_data():
+    """
+    Returns a default NXdata instance.
+    """
+    return NXdata()
+
+
+@pytest.fixture
+def NXdata_from_empty_01(empty_data, x, y, z, v):
+    empty_data.nxsignal = v
+    empty_data.nxaxes = (z, y, x)
+    return empty_data
+
+
+@pytest.fixture
+def NXdata_from_empty_02(empty_data, x, y, z, v):
+    empty_data["v"] = v
+    empty_data["x"] = x
+    empty_data["y"] = y
+    empty_data["z"] = z
+    empty_data.nxsignal = "v"
+    empty_data.nxaxes = ("z", "y", "x")
+    return empty_data
+
+
+def test_data_creation(data):
+
     assert "signal" in data.attrs
     assert "axes" in data.attrs
     assert len(data.attrs["axes"]) == 3
-    
     assert data.ndim == 3
     assert data.shape == (2, 5, 10)
     assert data.nxsignal.nxname == "v"
@@ -33,9 +67,8 @@ def test_data_creation():
     assert data.nxtitle == "Title"
 
 
-def test_default_data():
+def test_default_data(data):
 
-    data = NXdata(v, (z, y, x), title="Title")
     root = NXroot(NXentry(data))
     root["entry/data"].set_default()
 
@@ -59,9 +92,7 @@ def test_default_data():
     assert root.plottable_data is root["entry/subentry/data"]
 
 
-def test_plottable_data():
-
-    data = NXdata(v, (z, y, x), title="Title")
+def test_plottable_data_01(data):
 
     assert data.is_plottable()
     assert data.plottable_data is data
@@ -70,9 +101,8 @@ def test_plottable_data():
     assert data.plot_axes == data.nxaxes
     assert data.nxsignal.valid_axes(data.nxaxes)
 
-    v2 = v[0]
-    v2.resize((1, 5, 10))
-    data2 = NXdata(v2)
+
+def test_plottable_data_02(data2):
 
     assert data2.shape == (1, 5, 10)
     assert data2.plot_shape == (5, 10)
@@ -80,24 +110,10 @@ def test_plottable_data():
     assert data2.plot_rank == data2.nxsignal.ndim - 1
 
 
-def test_signal_selection():
-
-    data = NXdata()
-    data.nxsignal = v
-    data.nxaxes = (z, y, x)
-
-    assert data.nxsignal.nxname == "v"
-    assert [axis.nxname for axis in data.nxaxes] == ["z", "y", "x"]
-    assert np.array_equal(data.nxsignal, v)
-    assert np.array_equal(data.nxaxes[0], z)
-
-    data = NXdata()
-    data["v"] = v
-    data["x"] = x
-    data["y"] = y
-    data["z"] = z
-    data.nxsignal = "v"
-    data.nxaxes = ("z", "y", "x")
+@pytest.mark.parametrize("data",
+                         [NXdata_from_empty_01, NXdata_from_empty_02],
+                         indirect=True)
+def test_signal_selection(data, z, v):
 
     assert data.nxsignal.nxname == "v"
     assert [axis.nxname for axis in data.nxaxes] == ["z", "y", "x"]
@@ -105,12 +121,9 @@ def test_signal_selection():
     assert np.array_equal(data.nxaxes[0], z)
 
 
-def test_rename():
+def test_rename(NXdata_from_empty_01):
 
-    data = NXdata()
-    data.nxsignal = v
-    data.nxaxes = (z, y, x)
-
+    data = NXdata_from_empty_01
     data["x"].rename("xx")
     data["y"].rename("yy")
     data["z"].rename("zz")
@@ -119,11 +132,11 @@ def test_rename():
     assert [axis.nxname for axis in data.nxaxes] == ["zz", "yy", "xx"]
 
 
-def test_size_one_axis():
+def test_size_one_axis(x, z):
 
     y1 = np.array((1), dtype=np.float64)
-    v1 =  NXfield(np.linspace(0, 10*1*2, num=10*1*2, dtype=np.int64), name="v")
-    v1.resize((2,1,10))
+    v1 = NXfield(np.linspace(0, 10*1*2, num=10*1*2, dtype=np.int64), name="v")
+    v1.resize((2, 1, 10))
 
     data = NXdata(v1, (z, y1, x))
 
@@ -136,9 +149,8 @@ def test_size_one_axis():
     assert data.nxsignal.valid_axes(data.plot_axes)
 
 
-def test_data_operations():
+def test_data_operations(data, v):
 
-    data = NXdata(v, (z, y, x))
     new_data = data + 1
 
     assert np.array_equal(new_data.nxsignal.nxvalue, v + 1)
@@ -181,7 +193,7 @@ def test_data_errors():
 
     data = NXdata(v1, (y1))
     data.nxerrors = e1
-    
+
     new_data = 2 * data
 
     assert np.array_equal(new_data.nxerrors, 2 * e1)
@@ -189,11 +201,11 @@ def test_data_errors():
     new_data = 2 * data - data
 
     assert np.array_equal(new_data.nxerrors, e1 * np.sqrt(5))
- 
+
     new_data = data - data / 2
 
     assert np.array_equal(new_data.nxerrors, e1 * np.sqrt(1.25))
-   
+
 
 def test_data_weights():
 
@@ -215,7 +227,7 @@ def test_data_weights():
 
     data = NXdata(v1, (y1))
     data.nxweights = w1
-    
+
     new_data = 2 * data
 
     assert np.array_equal(new_data.nxweights, 2 * w1)
@@ -223,17 +235,15 @@ def test_data_weights():
     new_data = 2 * data - data
 
     assert np.array_equal(new_data.nxweights, w1)
- 
+
     new_data = data - data / 2
 
     assert np.array_equal(new_data.nxweights, w1/2)
-   
 
-def test_data_slabs():
 
-    data = NXdata(v, (z, y, x), title="Title")
- 
-    slab = data[0,:,:]
+def test_data_slabs(data, x, y, v):
+
+    slab = data[0, :, :]
 
     assert np.array_equal(slab.nxsignal, v[0])
     assert slab.plot_rank == 2
@@ -258,7 +268,7 @@ def test_data_slabs():
     assert slab2.shape == slab.shape
 
 
-def test_data_projections():
+def test_data_projections(x, y, z, v):
 
     d1 = NXdata(v[0], (y, x))
 
@@ -275,7 +285,7 @@ def test_data_projections():
 
     d2 = NXdata(v, (z, y, x))
 
-    p3 = d2.project((0,1),((0.,8.),(3.,9.),(4.,16.)))
+    p3 = d2.project((0, 1), ((0., 8.), (3., 9.), (4., 16.)))
 
     assert p3.nxaxes == [p3["z"], p3["y"]]
     assert np.array_equal(p3["y"].nxvalue, d2["y"][3.:9.])
@@ -284,14 +294,15 @@ def test_data_projections():
     assert p3["x"].attrs["minimum"] == 4.
     assert p3["x"].attrs["maximum"] == 16.
     assert p3["x"].attrs["summed_bins"] == 7
-    assert p3["v"].sum() == d2.v[:,1:3,2:8].sum()
-    
-    p4 = d2.project((0,1),((0.,8.),(3.,9.),(4.,16.)), summed=False)
+    assert p3["v"].sum() == d2.v[:, 1:3, 2:8].sum()
 
-    assert p4["v"].sum() == d2.v[:,1:3,2:8].sum() / p4["x"].attrs["summed_bins"]
+    p4 = d2.project((0, 1), ((0., 8.), (3., 9.), (4., 16.)), summed=False)
+
+    assert p4["v"].sum() == d2.v[:, 1:3, 2:8].sum() / \
+        p4["x"].attrs["summed_bins"]
 
 
-def test_data_smoothing():
+def test_data_smoothing(x):
 
     warnings.filterwarnings("ignore", message="numpy.ufunc size changed")
     data = NXdata(np.sin(x), (x))
@@ -303,7 +314,7 @@ def test_data_smoothing():
     assert smooth_data.nxsignal[-1] == np.sin(x)[-1]
 
     smooth_data = data.smooth(factor=4)
-    
+
     assert smooth_data.nxsignal.shape == (41,)
     assert smooth_data.nxaxes[0].shape == (41,)
     assert smooth_data.nxsignal[0] == np.sin(x)[0]
@@ -317,27 +328,27 @@ def test_data_selection():
     yy = np.ones(shape=xx.shape, dtype=float)
     yy[np.where(np.remainder(xx, 4) == 0.0)] = 2.0
     data = NXdata(yy, xx)
-    
+
     selected_data = data.select(4.0)
 
     assert selected_data.shape == (6,)
-    assert np.all(selected_data.nxsignal==2.0)
+    assert np.all(selected_data.nxsignal == 2.0)
 
-    yy[(np.array((1,3,5,7,9,11,13,15,17,19)),)] = 1.5
+    yy[(np.array((1, 3, 5, 7, 9, 11, 13, 15, 17, 19)),)] = 1.5
     data = NXdata(yy, xx)
 
     selected_data = data.select(4.0, offset=1.0)
 
     assert selected_data.shape == (5,)
-    assert np.all(selected_data.nxsignal==1.5)
+    assert np.all(selected_data.nxsignal == 1.5)
 
     selected_data = data.select(4.0, offset=1.0, symmetric=True)
 
     assert selected_data.shape == (10,)
-    assert np.all(selected_data.nxsignal==1.5)
+    assert np.all(selected_data.nxsignal == 1.5)
 
 
-def test_image_data():
+def test_image_data(x, y, z, v, im):
 
     root = NXroot(NXentry(NXdata(im)))
     root["entry"].attrs["default"] = "data"
@@ -350,25 +361,25 @@ def test_image_data():
     assert not root["entry/other_data"].is_image()
 
 
-def test_smart_indices():
+def test_smart_indices(x, v):
 
-    ind = [1,3,5]
+    ind = [1, 3, 5]
 
     assert all(x[ind].nxvalue == x.nxvalue[ind])
-    assert all(v[v>50].nxvalue == v.nxvalue[v.nxvalue>50])
-    assert all(v[1,0,ind].nxvalue == v.nxvalue[1,0,ind])
+    assert all(v[v > 50].nxvalue == v.nxvalue[v.nxvalue > 50])
+    assert all(v[1, 0, ind].nxvalue == v.nxvalue[1, 0, ind])
 
     x[ind] = 0
 
     assert x.any() and not x[ind].any()
 
-    ind = np.array([[3, 7],[4, 5]])
+    ind = np.array([[3, 7], [4, 5]])
 
     assert np.all(x[ind].nxvalue == x.nxvalue[ind])
 
     row = np.array([0, 1, 2])
     col = np.array([2, 1, 3])
 
-    assert all(v[0][row,col].nxvalue == v[0].nxvalue[row,col])
-    assert np.all(v[0][row[:,np.newaxis],col].nxvalue == 
-                  v[0].nxvalue[row[:,np.newaxis],col])
+    assert all(v[0][row, col].nxvalue == v[0].nxvalue[row, col])
+    assert np.all(v[0][row[:, np.newaxis], col].nxvalue ==
+                  v[0].nxvalue[row[:, np.newaxis], col])

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -110,15 +110,17 @@ def test_plottable_data_02(data2):
     assert data2.plot_rank == data2.nxsignal.ndim - 1
 
 
-@pytest.mark.parametrize("data",
-                         [NXdata_from_empty_01, NXdata_from_empty_02],
-                         indirect=True)
-def test_signal_selection(data, z, v):
+@pytest.mark.parametrize(
+    "data_",
+    [pytest.lazy_fixture('NXdata_from_empty_01'),
+     pytest.lazy_fixture('NXdata_from_empty_02')]
+)
+def test_signal_selection(data_, z, v):
 
-    assert data.nxsignal.nxname == "v"
-    assert [axis.nxname for axis in data.nxaxes] == ["z", "y", "x"]
-    assert np.array_equal(data.nxsignal, v)
-    assert np.array_equal(data.nxaxes[0], z)
+    assert data_.nxsignal.nxname == "v"
+    assert [axis.nxname for axis in data_.nxaxes] == ["z", "y", "x"]
+    assert np.array_equal(data_.nxsignal, v)
+    assert np.array_equal(data_.nxaxes[0], z)
 
 
 def test_rename(NXdata_from_empty_01):

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -111,16 +111,17 @@ def test_plottable_data_02(data2):
 
 
 @pytest.mark.parametrize(
-    "data_",
-    [pytest.lazy_fixture('NXdata_from_empty_01'),
-     pytest.lazy_fixture('NXdata_from_empty_02')]
+    "data_fixture_name",
+    ['NXdata_from_empty_01',
+     'NXdata_from_empty_02']
 )
-def test_signal_selection(data_, z, v):
+def test_signal_selection(data_fixture_name, z, v, request):
 
-    assert data_.nxsignal.nxname == "v"
-    assert [axis.nxname for axis in data_.nxaxes] == ["z", "y", "x"]
-    assert np.array_equal(data_.nxsignal, v)
-    assert np.array_equal(data_.nxaxes[0], z)
+    data = request.getfixturevalue(data_fixture_name)
+    assert data.nxsignal.nxname == "v"
+    assert [axis.nxname for axis in data.nxaxes] == ["z", "y", "x"]
+    assert np.array_equal(data.nxsignal, v)
+    assert np.array_equal(data.nxaxes[0], z)
 
 
 def test_rename(NXdata_from_empty_01):

--- a/tests/test_entry_groups.py
+++ b/tests/test_entry_groups.py
@@ -1,44 +1,56 @@
 import numpy as np
 import pytest
-from nexusformat.nexus import *
-
-x = NXfield(2 * np.linspace(0.0, 10.0, 11, dtype=np.float64), name="x")
-y = NXfield(3 * np.linspace(0.0, 5.0, 6, dtype=np.float64), name="y")
-z = NXfield(4 * np.linspace(0.0, 2.0, 3, dtype=np.float64), name="z")
-v = NXfield(np.linspace(0, 10*5*2, num=10*5*2, dtype=np.float64), name="v")
-v.resize((2,5,10))
+from nexusformat.nexus.tree import NXentry, NXdata, NXsample
 
 
-def test_entry_operations():
-
-    e1 = NXentry(NXdata(2*v, (z, y, x), name='d1'), NXsample(name='s1'))
-    e1.attrs['default'] = 'd1'
-    e2 = NXentry(NXdata(v, (z, y, x), name='d1'))
-    
-    e3 = e1 + e2
-
-    assert 'd1' in e3
-    assert 's1' in e3
-    assert e3.attrs['default'] == 'd1'
-    assert np.array_equal(e3.d1.nxsignal.nxvalue, 3*v)
-    assert e3.d1.nxaxes == e1.d1.nxaxes
-    assert e3.d1.nxsignal.nxname == "v"
-    assert [axis.nxname for axis in e3.d1.nxaxes] == ["z", "y", "x"]
-
-    e3 = e1 - e2
-
-    assert 'd1' in e3
-    assert 's1' in e3
-    assert np.array_equal(e3.d1.nxsignal.nxvalue, v)
-    assert e3.d1.nxaxes == e1.d1.nxaxes
-    assert e3.d1.nxsignal.nxname == "v"
-    assert [axis.nxname for axis in e3.d1.nxaxes] == ["z", "y", "x"]
+@pytest.fixture
+def entry_1(x, y, z, v):
+    """Simple entry."""
+    entry = NXentry(NXdata(2*v, (z, y, x), name='d1'), NXsample(name='s1'))
+    entry.attrs['default'] = 'd1'
+    return entry
 
 
-def test_plottable_data():
+@pytest.fixture
+def entry_2(x, y, z, v):
+    """Simple entry, but different to entry_1"""
+    return NXentry(NXdata(v, (z, y, x), name='d1'))
 
-    entry = NXentry(NXdata(v, (z, y, x), name='d1'), NXsample(name='s1'))
 
-    assert entry.is_plottable()
-    assert entry.plottable_data is entry['d1']
+@pytest.fixture
+def entry_3(entry_1, entry_2):
+    """Simple linear combination of entries."""
+    return entry_1 + entry_2
 
+
+@pytest.fixture
+def entry_4(entry_1, entry_2):
+    """Second simple linear combination of entries"""
+    return entry_1 - entry_2
+
+
+def test_entry_operation_values(entry_3, entry_4, v):
+
+    assert np.array_equal(entry_3.d1.nxsignal.nxvalue, 3*v)
+    assert np.array_equal(entry_4.d1.nxsignal.nxvalue, v)
+
+
+@pytest.mark.parametrize(
+    "entry",
+    [pytest.lazy_fixture('entry_3'), pytest.lazy_fixture('entry_4')]
+)
+def test_entry_operations(entry, entry_1):
+
+    assert 'd1' in entry
+    assert 's1' in entry
+    assert entry.attrs['default'] == 'd1'
+
+    assert entry.d1.nxaxes == entry_1.d1.nxaxes
+    assert entry.d1.nxsignal.nxname == "v"
+    assert [axis.nxname for axis in entry.d1.nxaxes] == ["z", "y", "x"]
+
+
+def test_plottable_data(entry_2):
+
+    assert entry_2.is_plottable()
+    assert entry_2.plottable_data is entry_2['d1']

--- a/tests/test_entry_groups.py
+++ b/tests/test_entry_groups.py
@@ -37,10 +37,11 @@ def test_entry_operation_values(entry_3, entry_4, v):
 
 @pytest.mark.parametrize(
     "entry",
-    [pytest.lazy_fixture('entry_3'), pytest.lazy_fixture('entry_4')]
+    ['entry_3', 'entry_4']
 )
-def test_entry_operations(entry, entry_1):
+def test_entry_operations(entry, entry_1, request):
 
+    entry = request.getfixturevalue(entry)
     assert 'd1' in entry
     assert 's1' in entry
     assert entry.attrs['default'] == 'd1'

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1,18 +1,22 @@
 import h5py as h5
 import numpy as np
 import pytest
-from nexusformat.nexus import *
+from nexusformat.nexus.tree import NXfield, nxgetencoding
 
-string_dtype = h5.special_dtype(vlen=str)
-NX_ENCODING = nxgetencoding()
 
-arr1D = np.linspace(0.0, 100.0, 101, dtype=np.float64)
-arr2D = np.array(((1,2,3,4),(5,6,7,8)), dtype=np.int32)
-arr3D = np.resize(np.linspace(0.0, 124.0, 125, dtype=np.float64), (5,5,5))
+@pytest.fixture
+def string_dtype():
+    return h5.special_dtype(vlen=str)
+
+
+@pytest.fixture
+def field():
+    return NXfield(shape=(10, 5, 5), dtype=np.int16, maxshape=(20, 10, 10),
+                   fillvalue=0)
 
 
 @pytest.mark.parametrize("text", ["a", "abc", "αβγ"])
-def test_string_field_creation(text):
+def test_string_field_creation(text, string_dtype):
 
     field = NXfield(text)
 
@@ -23,18 +27,22 @@ def test_string_field_creation(text):
 
 
 @pytest.mark.parametrize("text", ["a", "abc", "αβγ"])
-def test_byte_field_creation(text):
+def test_byte_field_creation(text, string_dtype):
 
     field = NXfield(text, dtype='S')
 
     assert field.nxvalue == text
-    assert field.nxdata.decode(NX_ENCODING) == text
+    assert field.nxdata.decode(nxgetencoding()) == text
     assert field.dtype != string_dtype
     assert field.is_string()
     assert len(field) == len(text)
 
 
-@pytest.mark.parametrize("arr", [arr1D, arr2D, arr3D])
+@pytest.mark.parametrize(
+    "arr",
+    [pytest.lazy_fixture("arr1D"),
+     pytest.lazy_fixture("arr2D"),
+     pytest.lazy_fixture("arr3D")])
 def test_array_field_creation(arr):
 
     field = NXfield(arr)
@@ -49,7 +57,11 @@ def test_array_field_creation(arr):
     assert field.reshape((field.size)) == NXfield(arr.reshape((arr.size)))
 
 
-@pytest.mark.parametrize("arr", [arr1D, arr2D, arr3D])
+@pytest.mark.parametrize(
+    "arr",
+    [pytest.lazy_fixture("arr1D"),
+     pytest.lazy_fixture("arr2D"),
+     pytest.lazy_fixture("arr3D")])
 def test_binary_field_operations(arr):
 
     field = NXfield(arr)
@@ -59,7 +71,11 @@ def test_binary_field_operations(arr):
     assert np.all((2*field).nxvalue == 2*arr)
 
 
-@pytest.mark.parametrize("arr", [arr1D, arr2D, arr3D])
+@pytest.mark.parametrize(
+    "arr",
+    [pytest.lazy_fixture("arr1D"),
+     pytest.lazy_fixture("arr2D"),
+     pytest.lazy_fixture("arr3D")])
 def test_field_methods(arr):
 
     field = NXfield(arr)
@@ -67,9 +83,10 @@ def test_field_methods(arr):
     assert field.sum() == np.sum(arr)
 
 
-@pytest.mark.parametrize("arr,idx", [(arr1D, np.s_[2:5]), 
-                                     (arr2D, np.s_[2:5,2:5]), 
-                                     (arr3D, np.s_[2:5,2:5,2:5])])
+@pytest.mark.parametrize(
+    "arr,idx", [(pytest.lazy_fixture("arr1D"), np.s_[2:5]),
+                (pytest.lazy_fixture("arr2D"), np.s_[2:5, 2:5]),
+                (pytest.lazy_fixture("arr3D"), np.s_[2:5, 2:5, 2:5])])
 def test_field_slice(arr, idx):
 
     field = NXfield(arr)
@@ -78,7 +95,7 @@ def test_field_slice(arr, idx):
     assert field[idx].shape == arr[idx].shape
 
 
-def test_field_index():
+def test_field_index(arr1D):
 
     field = NXfield(2*arr1D)
 
@@ -95,23 +112,21 @@ def test_field_index():
     assert field.index(12., max=True) == 94
 
 
-def test_field_resize():
+def test_field_resize(field):
 
-    field = NXfield(shape=(10,5,5), dtype=np.int16, maxshape=(20,10,10), 
-                    fillvalue=0)
     field[9] = 1
 
-    assert field.shape == (10,5,5)
+    assert field.shape == (10, 5, 5)
     assert field.sum() == 25
 
-    field.resize((15,5,5))
+    field.resize((15, 5, 5))
     field[14] = 1
 
-    assert field.shape == (15,5,5)
+    assert field.shape == (15, 5, 5)
     assert field.sum() == 50
 
-    field.resize((15,5,10))
-    field[:,:,9] = 1
+    field.resize((15, 5, 10))
+    field[:, :, 9] = 1
 
-    assert field.shape == (15,5,10)
-    assert field[:,:,9].sum() == 75
+    assert field.shape == (15, 5, 10)
+    assert field[:, :, 9].sum() == 75

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -40,11 +40,12 @@ def test_byte_field_creation(text, string_dtype):
 
 @pytest.mark.parametrize(
     "arr",
-    [pytest.lazy_fixture("arr1D"),
-     pytest.lazy_fixture("arr2D"),
-     pytest.lazy_fixture("arr3D")])
-def test_array_field_creation(arr):
+    ["arr1D",
+     "arr2D",
+     "arr3D"])
+def test_array_field_creation(arr, request):
 
+    arr = request.getfixturevalue(arr)
     field = NXfield(arr)
 
     assert np.all(field.nxvalue == arr)
@@ -59,11 +60,12 @@ def test_array_field_creation(arr):
 
 @pytest.mark.parametrize(
     "arr",
-    [pytest.lazy_fixture("arr1D"),
-     pytest.lazy_fixture("arr2D"),
-     pytest.lazy_fixture("arr3D")])
-def test_binary_field_operations(arr):
+    ["arr1D",
+     "arr2D",
+     "arr3D"])
+def test_binary_field_operations(arr, request):
 
+    arr = request.getfixturevalue(arr)
     field = NXfield(arr)
 
     assert np.all((field+2).nxvalue == arr+2)
@@ -73,22 +75,24 @@ def test_binary_field_operations(arr):
 
 @pytest.mark.parametrize(
     "arr",
-    [pytest.lazy_fixture("arr1D"),
-     pytest.lazy_fixture("arr2D"),
-     pytest.lazy_fixture("arr3D")])
-def test_field_methods(arr):
+    ["arr1D",
+     "arr2D",
+     "arr3D"])
+def test_field_methods(arr, request):
 
+    arr = request.getfixturevalue(arr)
     field = NXfield(arr)
 
     assert field.sum() == np.sum(arr)
 
 
 @pytest.mark.parametrize(
-    "arr,idx", [(pytest.lazy_fixture("arr1D"), np.s_[2:5]),
-                (pytest.lazy_fixture("arr2D"), np.s_[2:5, 2:5]),
-                (pytest.lazy_fixture("arr3D"), np.s_[2:5, 2:5, 2:5])])
-def test_field_slice(arr, idx):
+    "arr,idx", [("arr1D", np.s_[2:5]),
+                ("arr2D", np.s_[2:5, 2:5]),
+                ("arr3D", np.s_[2:5, 2:5, 2:5])])
+def test_field_slice(arr, idx, request):
 
+    arr = request.getfixturevalue(arr)
     field = NXfield(arr)
 
     assert np.array_equal(field[idx].nxvalue, arr[idx])

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -1,6 +1,6 @@
 import os
 import pytest
-from nexusformat.nexus.tree import NXfield, NXroot, NXentry, NXdata, NXFile, \
+from nexusformat.nexus.tree import NXroot, NXentry, NXdata, NXFile, \
     nxload
 
 

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -1,12 +1,7 @@
-import numpy as np
 import os
 import pytest
-import six
-from nexusformat.nexus import *
-
-field1 = NXfield((1,2), name="f1")
-field2 = NXfield((3,4), name="f2")
-field3 = NXfield((5,6), name="f3")
+from nexusformat.nexus.tree import NXfield, NXroot, NXentry, NXdata, NXFile, \
+    nxload
 
 
 def test_file_creation(tmpdir):
@@ -18,7 +13,7 @@ def test_file_creation(tmpdir):
     assert not f.is_open()
 
 
-def test_file_save(tmpdir):
+def test_file_save(tmpdir, field1, field2):
 
     filename = os.path.join(tmpdir, "file.nxs")
 
@@ -41,7 +36,7 @@ def test_file_save(tmpdir):
 
 
 @pytest.mark.parametrize("recursive", ["True", "False"])
-def test_file_recursion(tmpdir, recursive):
+def test_file_recursion(tmpdir, field1, field2, recursive):
 
     filename = os.path.join(tmpdir, "file.nxs")
     w1 = NXroot(NXentry())
@@ -63,5 +58,3 @@ def test_file_recursion(tmpdir, recursive):
     assert "entry/data/f2" in w2
     assert "signal" in w2["entry/data"].attrs
     assert "axes" in w2["entry/data"].attrs
-        
-

--- a/tests/test_groups.py
+++ b/tests/test_groups.py
@@ -1,14 +1,9 @@
 import os
-import pytest
-from nexusformat.nexus import *
+from nexusformat.nexus.tree import NXgroup, NXentry, NXdata, NXgroup, NXlink, \
+    NXroot
 
 
-field1 = NXfield((1,2), name="f1")
-field2 = NXfield((3,4), name="f2")
-field3 = NXfield((5,6), name="f3")
-
-
-def test_group_creation():
+def test_group_creation(field1, field2, field3):
 
     group1 = NXgroup(name="group")
 
@@ -22,7 +17,7 @@ def test_group_creation():
     assert group2
     assert len(group2) == 1
     assert "f1" in group2
-    
+
     group1["f2"] = field2
 
     assert "f2" in group1
@@ -42,10 +37,10 @@ def test_group_creation():
     group3 = NXgroup(g1=group1)
 
     assert "g1/g2/f1" in group3
-    assert group3["g1"].nxgroup == group3    
+    assert group3["g1"].nxgroup == group3
 
 
-def test_group_insertion():
+def test_group_insertion(field2):
 
     group1 = NXgroup()
 
@@ -55,7 +50,7 @@ def test_group_insertion():
     assert len(group1) == 1
 
 
-def test_rename():
+def test_rename(field1):
 
     group = NXgroup(field1)
 
@@ -80,7 +75,7 @@ def test_group_class():
 
     group = NXgroup()
     group.nxclass = NXentry
-    
+
     assert group.nxclass == "NXentry"
     assert isinstance(group, NXentry)
 
@@ -104,7 +99,7 @@ def test_group_title():
     assert group.nxtitle == "Group Title"
 
 
-def test_group_move():
+def test_group_move(field1):
 
     group = NXentry()
     group['g1'] = NXgroup()
@@ -127,14 +122,15 @@ def test_group_move():
     assert group['g3/f3'].nxlink == field1
 
 
-def test_group_copy(tmpdir):
+def test_group_copy(tmpdir, field1):
 
     filename = os.path.join(tmpdir, "file1.nxs")
     root = NXroot(NXentry())
     root.save(filename, mode="w")
 
     external_filename = os.path.join(tmpdir, "file2.nxs")
-    external_root = NXroot(NXentry(NXgroup(field1, name='g1', attrs={"a":"b"})))
+    external_root = NXroot(
+        NXentry(NXgroup(field1, name='g1', attrs={"a": "b"})))
     external_root.save(external_filename, mode="w")
 
     root["entry/g2"] = NXlink(target="entry/g1", file=external_filename)
@@ -144,7 +140,7 @@ def test_group_copy(tmpdir):
     copied_root.save(copied_filename, mode="w")
 
     copied_root["entry"] = root["entry"].copy(expand_external=True)
-    
+
     assert "entry" in copied_root
     assert "g2" in copied_root["entry"]
     assert "entry/g2/f1" in copied_root
@@ -154,7 +150,7 @@ def test_group_copy(tmpdir):
     assert copied_root["entry/g2"].attrs["a"] == "b"
 
 
-def test_field_copy(tmpdir):
+def test_field_copy(tmpdir, field1):
 
     filename = os.path.join(tmpdir, "file1.nxs")
     root = NXroot(NXentry(NXgroup(name="g1")))
@@ -171,7 +167,7 @@ def test_field_copy(tmpdir):
     copied_root.save(copied_filename, mode="w")
 
     copied_root["entry/g3/f1"] = root["entry/g1/f1"].copy()
-    
+
     assert "entry/g3/f1" in copied_root
     assert not isinstance(copied_root["entry/g3/f1"], NXlink)
     assert copied_root["entry/g3/f1"][0] == 1

--- a/tests/test_locks.py
+++ b/tests/test_locks.py
@@ -1,23 +1,20 @@
 import os
-import pytest
 import time
-from nexusformat.nexus import *
-from nexusformat.nexus.tree import text
-
-field1 = NXfield("a", name="f1")
+from nexusformat.nexus.tree import nxsetlock, text, NXroot, NXentry, NXLock, \
+    nxload
 
 
-def test_lock_creation(tmpdir):
+def test_lock_creation(tmpdir, field4):
 
     nxsetlock(0)
     filename = os.path.join(tmpdir, "file1.nxs")
-    root = NXroot(NXentry(field1))
+    root = NXroot(NXentry(field4))
     root.save(filename)
 
     assert root.nxfile.lock is not None
 
     root.nxfile.acquire_lock()
-    
+
     assert not root.nxfile.locked
     assert not root.nxfile.is_locked()
 
@@ -36,15 +33,15 @@ def test_lock_creation(tmpdir):
     root["entry/f1"] = "b"
 
     assert root["entry/f1"] == "b"
-    
+
     assert not root.nxfile.locked
     assert not root.nxfile.is_locked()
 
 
-def test_locked_assignments(tmpdir):
+def test_locked_assignments(tmpdir, field4):
 
     filename = os.path.join(tmpdir, "file1.nxs")
-    root = NXroot(NXentry(field1))
+    root = NXroot(NXentry(field4))
     root.save(filename)
 
     assert root.nxfile.mtime == os.path.getmtime(filename)
@@ -55,7 +52,7 @@ def test_locked_assignments(tmpdir):
     root["entry/f1"] = "b"
 
     assert root["entry/f1"] == "b"
-    
+
     root.nxfile.lock = 10
 
     assert isinstance(root.nxfile.lock, NXLock)
@@ -70,10 +67,10 @@ def test_locked_assignments(tmpdir):
     assert root.mtime > originalmtime
 
 
-def test_lock_interactions(tmpdir):
+def test_lock_interactions(tmpdir, field4):
 
     filename = os.path.join(tmpdir, "file1.nxs")
-    root = NXroot(NXentry(field1))
+    root = NXroot(NXentry(field4))
     root.save(filename)
 
     assert not root.nxfile.is_open()
@@ -89,11 +86,11 @@ def test_lock_interactions(tmpdir):
     assert root1.mtime > root2.mtime
 
 
-def test_lock_defaults(tmpdir):  
+def test_lock_defaults(tmpdir, field4):
 
     nxsetlock(20)
     filename = os.path.join(tmpdir, "file1.nxs")
-    root = NXroot(NXentry(field1))
+    root = NXroot(NXentry(field4))
     root.save(filename, "w")
 
     with root.nxfile as f:
@@ -101,13 +98,13 @@ def test_lock_defaults(tmpdir):
         assert isinstance(root.nxfile.lock, NXLock)
         assert root.nxfile.lock.timeout == 20
         assert root.nxfile.locked
-        assert root.nxfile.is_locked()    
+        assert root.nxfile.is_locked()
 
     assert not root.nxfile.locked
     assert not root.nxfile.is_locked()
 
     nxsetlock(0)
-    root = NXroot(NXentry(field1))
+    root = NXroot(NXentry(field4))
     root.save(filename, "w")
 
     with root.nxfile as f:
@@ -116,10 +113,10 @@ def test_lock_defaults(tmpdir):
         assert not root.nxfile.is_locked()
 
 
-def test_nested_locks(tmpdir):
+def test_nested_locks(tmpdir, field4):
 
     filename = os.path.join(tmpdir, "file1.nxs")
-    root = NXroot(NXentry(field1))
+    root = NXroot(NXentry(field4))
     root.save(filename, "w")
     root.nxfile.lock = True
 

--- a/tests/test_masks.py
+++ b/tests/test_masks.py
@@ -1,12 +1,10 @@
 import numpy as np
 import os
 import pytest
-from nexusformat.nexus import *
-
-arr1D = np.linspace(0.0, 100.0, 101, dtype=np.float64)
+from nexusformat.nexus.tree import NXfield, NXroot, nxload, NXgroup
 
 
-def test_field_masks():
+def test_field_masks(arr1D):
     field = NXfield(arr1D)
     field[10:20] = np.ma.masked
 
@@ -25,7 +23,7 @@ def test_field_masks():
 
 
 @pytest.mark.parametrize("save", ["False", "True"])
-def test_group_masks(tmpdir, save):
+def test_group_masks(tmpdir, arr1D, save):
     group = NXgroup(NXfield(arr1D, name='field'))
     group['field'][10:20] = np.ma.masked
 
@@ -48,4 +46,3 @@ def test_group_masks(tmpdir, save):
 
     assert np.all(group['field'].mask[10:12] == np.array([False, True]))
     assert np.all(group['field_mask'][10:12] == np.array([False, True]))
-

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -1,4 +1,3 @@
-import pytest
 from nexusformat.nexus.tree import NXroot, NXgroup, NXentry
 
 

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -1,10 +1,8 @@
 import pytest
-from nexusformat.nexus import *
-
-field1 = NXfield((1,2), name="f1")
+from nexusformat.nexus.tree import NXroot, NXgroup, NXentry
 
 
-def test_attribute_paths():
+def test_attribute_paths(field1):
 
     root = NXroot(NXentry())
     root.entry.g1 = NXgroup(field1)
@@ -18,7 +16,7 @@ def test_attribute_paths():
     assert root.entry.g1.f1.nxroot is root
 
 
-def test_dictionary_paths():
+def test_dictionary_paths(field1):
 
     root = NXroot(NXentry())
     root["entry/g1"] = NXgroup(field1)
@@ -32,7 +30,7 @@ def test_dictionary_paths():
     assert root["/entry/g1/f1"].nxroot is root
 
 
-def test_relative_paths():
+def test_relative_paths(field1):
 
     root = NXroot(NXentry())
     root["entry/g1"] = NXgroup()


### PR DESCRIPTION
I noticed that the tests made extensive use of global variables, wildcard imports, multiple assertions per test, and generally looked in need of some work. 

I replaced all global variables with pytest fixtures, removed all wildcard imports, updated requirements.txt to reflect the dependency on pytest (and the lazy_fixtures plugin which is arguably essential, see e.g. https://github.com/pytest-dev/pytest/issues/349). With regards to multiple assertions, I only touched a couple of tests that could be refactored easily.

Functionally, this refactor changes nothing, but at least now you know that no two tests can affect each other's state thanks to fixtures.