### PR TITLE
Minor fixes

### DIFF
--- a/README
+++ b/README
@@ -14,15 +14,13 @@ repository <https://github.com/nexpy/nexusformat>.
 Installing and Running
 ======================
 
-Released versions of NeXpy-RO are available on PyPI. If you have the Python 
-Setup Tools <https://pypi.python.org/pypi/setuptools> installed, then you can 
-install using either::
+Released versions of this package can be installed using either
 
     $ pip install nexusformat
 
-or:: 
+or, if you are in a conda environment,
 
-    $ easy_install nexusformat 
+    $ conda install -c conda-forge nexusformat
 
 The latest development versions of nexpy-api can be downloaded from the NeXpy 
 Git repository <https://github.com/nexpy/nexusformat>.

--- a/README.md
+++ b/README.md
@@ -17,16 +17,10 @@ Released versions of `nexusformat` can be installed using either
     $ pip install nexusformat
 ```
 
-or
+or, if you are in a conda environment::
 
 ```
-    $ easy_install nexusformat
-```
-
-If you have an Anaconda installation, use::
-
-```
-    $ conda install -c nexpy nexusformat
+    $ conda install -c conda-forge nexusformat
 ```
 
 The source code can be downloaded from the NeXpy Git repository:

--- a/README.rst
+++ b/README.rst
@@ -1,21 +1,14 @@
 Installation
 ============
-Released versions of the NeXus Python API are available on `PyPI 
-<https://pypi.python.org/pypi/nexusformat/>`_. If you have the `Python Setup 
-Tools <https://pypi.python.org/pypi/setuptools>`_ installed, then you can 
-install using either::
+Released versions of this package can be installed using either::
 
     $ pip install nexusformat
 
-or:: 
+or, if you are in a conda environment::
 
-    $ easy_install nexusformat 
+    $ conda install -c conda-forge nexusformat
 
-or::
-
-    $ conda install -c https://conda.anaconda.org/nexpy nexusformat
-
-If you have trouble with the pip or easy_install installations, you can install
+If you have trouble with the pip or conda installations, you can install
 the package from the source code either by downloading one of the 
 `Github releases <https://github.com/nexpy/nexusformat/releases>`_ or by cloning 
 the latest development version in the 

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -16,13 +16,11 @@ requirements:
   build:
     - python >=3.6
     - setuptools
-    - versioneer
 
   run:
     - python >=3.6
     - numpy >=1.16
     - h5py
-    - versioneer
 
 test:
   commands:

--- a/src/nexusformat/nexus/plot.py
+++ b/src/nexusformat/nexus/plot.py
@@ -10,6 +10,7 @@
 
 """Module to provide standard Matplotlib plotting to the NeXus Python API."""
 import copy
+
 import numpy as np
 
 from . import NeXusError, NXfield
@@ -222,8 +223,8 @@ class PylabPlotter(object):
 
             # Two dimensional plot
             else:
-                from matplotlib.colors import LogNorm, Normalize
                 from matplotlib.cm import get_cmap
+                from matplotlib.colors import LogNorm, Normalize
 
                 if image:
                     x = boundaries(axes[-1], data.shape[-2])
@@ -277,14 +278,15 @@ class PylabPlotter(object):
                     if colorbar:
                         cb = plt.colorbar(im)
                         if cmap == 'tab10':
-                            from matplotlib import __version__
+                            from matplotlib import mpl_version
+                            from pkg_resources import parse_version as pv
                             cmin, cmax = im.get_clim()
                             if cmax - cmin <= 9:
                                 if cmin == 0:
                                     im.set_clim(-0.5, 9.5)
                                 elif cmin == 1:
                                     im.set_clim(0.5, 10.5)
-                                if __version__ >= '3.5.0':
+                                if pv(mpl_version) >= pv('3.5.0'):
                                     cb.ax.set_ylim(cmin-0.5, cmax+0.5)
                                     cb.set_ticks(range(int(cmin), int(cmax)+1))
 

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -5345,6 +5345,13 @@ class NXroot(NXgroup):
         self._file_modified = False
         NXgroup.__init__(self, *args, **kwargs)
 
+    def __repr__(self):
+        """Customize display of NXroot when associated with a file."""
+        if self.nxfilename:
+            return f"NXroot('{os.path.basename(self.nxfilename)}')"
+        else:
+            return f"NXroot('{self.nxname}')"
+
     def reload(self):
         """Reload the NeXus file from disk."""
         if self.nxfilemode:


### PR DESCRIPTION
* Display the filename of saved `NXroot` objects in `__repr__` to make them easier to identify.
* Use `pkg_resources.parse_version` for more robust version number checks.
* Update README files.