### PR TITLE
Virtual Fields

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -42,10 +42,11 @@ nexusformat = notebooks/*.ipynb
 
 [options.entry_points]
 console_scripts =
-    nxstack = nexusformat.scripts.nxstack:main
+    nexusformat = nexusformat.scripts.nexusformat:main
+    nxconsolidate = nexusformat.scripts.nxconsolidate:main
     nxdir = nexusformat.scripts.nxdir:main
     nxduplicate = nexusformat.scripts.nxduplicate:main
-    nexusformat = nexusformat.scripts.nexusformat:main
+    nxstack = nexusformat.scripts.nxstack:main
 
 [options.extras_require]
 testing = pytest

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,6 +43,7 @@ nexusformat = notebooks/*.ipynb
 [options.entry_points]
 console_scripts =
     nxstack = nexusformat.scripts.nxstack:main
+    nxdir = nexusformat.scripts.nxdir:main
     nxduplicate = nexusformat.scripts.nxduplicate:main
     nexusformat = nexusformat.scripts.nexusformat:main
 

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -7296,16 +7296,21 @@ def duplicate(input_file, output_file, mode='w-', **kwargs):
 nxduplicate = duplicate
 
 
-def directory(filename):
+def directory(filename, short=False):
     """Print the contents of the named NeXus file.
 
     Parameters
     ----------
     filename : str
         Name of the file to be read.
+    short : bool, optional
+        True if only a short tree is to be printed, by default False
     """
     root = load(filename)
-    print(root.tree)
+    if short:
+        print(root.short_tree)
+    else:
+        print(root.tree)
 
 
 nxdir = directory

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -841,7 +841,8 @@ class NXFile(object):
                 target = sources[0].dset_name
                 files = [s.file_name for s in sources]
                 return NXvirtualfield(target, files, name=name, attrs=attrs,
-                                      shape=field.shape[1:], dtype=field.dtype)
+                                      shape=field.shape[1:], dtype=field.dtype,
+                                      create_vds=False)
             else:
                 return NXfield(value=value, name=name, dtype=field.dtype,
                                shape=field.shape, attrs=attrs)
@@ -4079,7 +4080,8 @@ class NXvirtualfield(NXfield):
     """
 
     def __init__(self, target, files, name='unknown', shape=None, dtype=None,
-                 group=None, attrs=None, abspath=False, **kwargs):
+                 group=None, attrs=None, abspath=False, create_vds=True,
+                 **kwargs):
         """Initialize the field containing the virtual dataset.
 
         Parameters
@@ -4119,7 +4121,7 @@ class NXvirtualfield(NXfield):
             self._vshape = None
         super().__init__(name=name, shape=self._vshape, dtype=dtype,
                          group=group, attrs=attrs, **kwargs)
-        if shape and dtype:
+        if create_vds and shape and dtype:
             self._create_virtual_data()
 
     def _create_virtual_data(self):

--- a/src/nexusformat/scripts/nxconsolidate.py
+++ b/src/nexusformat/scripts/nxconsolidate.py
@@ -10,7 +10,6 @@ import argparse
 
 from nexusformat import __version__
 from nexusformat.nexus import NXentry, NXroot, nxconsolidate
-from nexusformat.nexus.tree import natural_sort
 
 
 def main():
@@ -21,8 +20,7 @@ def main():
                         help="name of NeXus input files (wild cards allowed)")
     parser.add_argument('-d', '--data', required=True,
                         help="path to the NXdata group")
-    parser.add_argument('-s', '--scan', required=True,
-                        help="path to the scan variable")
+    parser.add_argument('-s', '--scan', help="path to the scan variable")
     parser.add_argument('-e', '--entry', default='entry',
                         help="name of NXentry group")
     parser.add_argument('-o', '--output', required=True,
@@ -32,8 +30,7 @@ def main():
 
     args = parser.parse_args()
 
-    scan_data = nxconsolidate(sorted(args.files, key=natural_sort), args.data,
-                              scan=args.scan)
+    scan_data = nxconsolidate(args.files, args.data, scan_path=args.scan)
     NXroot(NXentry(scan_data, name=args.entry)).save(args.output, 'w-')
 
 

--- a/src/nexusformat/scripts/nxconsolidate.py
+++ b/src/nexusformat/scripts/nxconsolidate.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+# -----------------------------------------------------------------------------
+# Copyright (c) 2019-2022, NeXpy Development Team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file COPYING, distributed with this software.
+# -----------------------------------------------------------------------------
+import argparse
+
+from nexusformat import __version__
+from nexusformat.nexus import NXentry, NXroot, nxconsolidate
+from nexusformat.nexus.tree import natural_sort
+
+
+def main():
+
+    parser = argparse.ArgumentParser(
+        description="Copy a NeXus file to another file")
+    parser.add_argument('files', action='store', nargs='*',
+                        help="name of NeXus input files (wild cards allowed)")
+    parser.add_argument('-d', '--data', required=True,
+                        help="path to the NXdata group")
+    parser.add_argument('-s', '--scan', required=True,
+                        help="path to the scan variable")
+    parser.add_argument('-e', '--entry', default='entry',
+                        help="name of NXentry group")
+    parser.add_argument('-o', '--output', required=True,
+                        help="name of NeXus output file")
+    parser.add_argument('-v', '--version', action='version',
+                        version=f'nxconsolidate v{__version__}')
+
+    args = parser.parse_args()
+
+    scan_data = nxconsolidate(sorted(args.files, key=natural_sort), args.data,
+                              scan=args.scan)
+    NXroot(NXentry(scan_data, name=args.entry)).save(args.output, 'w-')
+
+
+if __name__ == "__main__":
+    main()

--- a/src/nexusformat/scripts/nxdir.py
+++ b/src/nexusformat/scripts/nxdir.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+# -----------------------------------------------------------------------------
+# Copyright (c) 2019-2021, NeXpy Development Team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file COPYING, distributed with this software.
+# -----------------------------------------------------------------------------
+import argparse
+
+from nexusformat import __version__
+from nexusformat.nexus import nxdir
+
+
+def main():
+
+    parser = argparse.ArgumentParser(
+        description="Print a NeXus file tree")
+    parser.add_argument('file', action='store', help="name of NeXus file")
+    parser.add_argument('-s', '--short', action='store_true',
+                        help="print only the first level")
+    parser.add_argument('-v', '--version', action='version',
+                        version=f'nxdir v{__version__}')
+
+    args = parser.parse_args()
+
+    nxdir(args.file, short=args.short)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -321,16 +321,16 @@ def test_data_smoothing(x):
 
     assert smooth_data.nxsignal.shape == (101,)
     assert smooth_data.nxaxes[0].shape == (101,)
-    assert smooth_data.nxsignal[0] == np.sin(x)[0]
-    assert smooth_data.nxsignal[-1] == np.sin(x)[-1]
+    assert smooth_data.nxsignal[0] == pytest.approx(np.sin(x)[0])
+    assert smooth_data.nxsignal[-1] == pytest.approx(np.sin(x)[-1])
 
     smooth_data = data.smooth(factor=4)
 
     assert smooth_data.nxsignal.shape == (41,)
     assert smooth_data.nxaxes[0].shape == (41,)
-    assert smooth_data.nxsignal[0] == np.sin(x)[0]
-    assert smooth_data.nxsignal[4] == np.sin(x)[1]
-    assert smooth_data.nxsignal[-1] == np.sin(x)[-1]
+    assert smooth_data.nxsignal[0] == pytest.approx(np.sin(x)[0])
+    assert smooth_data.nxsignal[4] == pytest.approx(np.sin(x)[1])
+    assert smooth_data.nxsignal[-1] == pytest.approx(np.sin(x)[-1])
 
 
 def test_data_selection():

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,8 +1,11 @@
+import os
 import warnings
 
 import numpy as np
 import pytest
-from nexusformat.nexus.tree import NXdata, NXentry, NXfield, NXroot, NXsubentry
+from nexusformat.nexus.tree import (NXdata, NXentry, NXfield, NXroot,
+                                    NXsubentry, NXvirtualfield, nxconsolidate,
+                                    nxload)
 
 
 @pytest.fixture
@@ -394,3 +397,41 @@ def test_smart_indices(x, v):
     assert all(v[0][row, col].nxvalue == v[0].nxvalue[row, col])
     assert np.all(v[0][row[:, np.newaxis], col].nxvalue ==
                   v[0].nxvalue[row[:, np.newaxis], col])
+
+
+@pytest.mark.parametrize("path", [True, False])
+def test_virtual_fields(tmpdir, path, v):
+
+    s1 = NXroot(NXentry(NXdata(v)))
+    s2 = NXroot(NXentry(NXdata(2*v)))
+    s3 = NXroot(NXentry(NXdata(3*v)))
+
+    s1.save(os.path.join(tmpdir, "s1.nxs"), "w")
+    s2.save(os.path.join(tmpdir, "s2.nxs"), "w")
+    s3.save(os.path.join(tmpdir, "s3.nxs"), "w")
+
+    sources = [f.nxfilename for f in [s1, s2, s3]]
+
+    if path:
+        vds1 = NXvirtualfield("entry/data/v", sources, shape=v.shape,
+                              dtype=v.dtype)
+    else:
+        vds1 = NXvirtualfield(s1["entry/data/v"], sources)
+
+    assert vds1.shape == (3,) + v.shape
+    assert vds1.dtype == v.dtype
+    assert vds1.sum() == 6 * v.sum()
+
+    vds2 = nxconsolidate(sources, "entry/data")
+
+    assert vds2.nxsignal.shape == vds1.shape
+    assert vds2.nxsignal.dtype == v.dtype
+    assert vds2.sum() == 6 * v.sum()
+
+    NXroot(NXentry(vds2)).save(os.path.join(tmpdir, "vds.nxs"), "w")
+    vds3 = nxload(os.path.join(tmpdir, "vds.nxs"))
+
+    assert "entry/data/v" in vds3
+    assert vds3["entry/data/v"].shape == vds1.shape
+    assert vds3["entry/data/v"].dtype == v.dtype
+    assert vds3["entry/data/v"].sum() == 6 * v.sum()

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -435,3 +435,4 @@ def test_virtual_fields(tmpdir, path, v):
     assert vds3["entry/data/v"].shape == vds1.shape
     assert vds3["entry/data/v"].dtype == v.dtype
     assert vds3["entry/data/v"].sum() == 6 * v.sum()
+    assert vds3.nxfile["entry/data/v"].is_virtual


### PR DESCRIPTION
* Adds a new `NXvirtualfield` class to implement h5py virtual datasets.
* Adds a new `nxconsolidate` function to generate  a NXdata group combining the equivalent NXdata group from multiple files using virtual datasets.
* Adds a new `nxconsolidate` script to use the `nxconsolidate` function from the command line.
* Adds a new `nxdir` script to print a NeXus file tree from the command line.
* Adds a `short` option to the `nxdir` function.
* Fixes float comparisons in Github Actions.