### PR TITLE
Removing stale locks

### DIFF
--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -689,8 +689,10 @@ class NXFile(object):
         if self.is_open():
             self._file.close()
         self.release_lock()
-        if self._root:
+        try:
             self._root._mtime = self.mtime
+        except Exception:
+            pass
 
     def is_open(self):
         """Return True if the file is open for input/output in h5py."""


### PR DESCRIPTION
* Allows a NeXus file to be locked when an existing lock file is more than a day old.
* Prevents exceptions when attempting to update a NXroot modification time when the NeXus file has been deleted.