### PR TITLE
Set time to expire stale locks

### DIFF
--- a/src/nexusformat/nexus/lock.py
+++ b/src/nexusformat/nexus/lock.py
@@ -117,7 +117,7 @@ class NXLock(object):
                 # Remove the lockfile if it is older than one day
                 elif initial_attempt and expiry:
                     if self.is_stale(expiry=expiry):
-                        os.remove(self.lock_file)
+                        self.clear()
                     initial_attempt = False
                 time.sleep(check_interval)
         # Raise an error if we had to wait for too long

--- a/tests/test_locks.py
+++ b/tests/test_locks.py
@@ -3,7 +3,7 @@ import time
 
 import pytest
 from nexusformat.nexus.tree import (NeXusError, NXentry, NXLock, NXroot,
-                                    nxload, nxsetlock, text)
+                                    nxload, nxsetlock, nxsetlockexpiry, text)
 
 
 def test_lock_creation(tmpdir, field4):
@@ -151,6 +151,7 @@ def test_nested_locks(tmpdir, field4):
 def test_stale_locks(tmpdir):
 
     nxsetlock(2)
+    nxsetlockexpiry(3600)
     filename = os.path.join(tmpdir, "file1.nxs")
     root = NXroot(NXentry())
     root.save(filename, "w")
@@ -167,7 +168,7 @@ def test_stale_locks(tmpdir):
     assert root.nxfile.is_locked()
 
     stat = os.stat(root.nxfile.lock_file)
-    os.utime(root.nxfile.lock_file, (stat.st_atime, stat.st_mtime - 100000))
+    os.utime(root.nxfile.lock_file, (stat.st_atime, stat.st_mtime - 10000))
 
     with root.nxfile:
 


### PR DESCRIPTION
* Allows the expiry time for stale locks to be configured.
* Catches a race condition where a lock is cleared before checking its file modification time.