### PR TITLE
Use pathlib for parsing external files and internal paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,7 @@ Icon?
 
 # setuptools_scm
 src/nexusformat/_version.py
+
+# miscellaneous system files
+.directoryhash
+ 

--- a/src/nexusformat/nexus/lock.py
+++ b/src/nexusformat/nexus/lock.py
@@ -109,6 +109,7 @@ class NXLock(object):
                 self.fd = os.open(self.lock_file,
                                   os.O_CREAT | os.O_EXCL | os.O_RDWR)
                 open(self.lock_file, 'w').write(str(self.pid))
+                os.chmod(self.lock_file, 0o777)
                 break
             except OSError as e:
                 # Only catch if the lockfile already exists

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -202,6 +202,8 @@ import re
 import sys
 import warnings
 from copy import copy, deepcopy
+from pathlib import Path
+from pathlib import PurePosixPath as PurePath
 
 import h5py as h5
 import numpy as np
@@ -413,10 +415,10 @@ class NXFile(object):
             Keyword arguments to be used when opening the h5py File object.
         """
         self.h5 = h5
-        self.name = name
+        self.name = str(name)
         self._file = None
-        self._filename = os.path.abspath(name)
-        self._filedir = os.path.dirname(self._filename)
+        self._filename = str(Path(name).resolve())
+        self._filedir = str(Path(self._filename).parent)
         self._lock = NXLock(self._filename, timeout=NX_LOCK,
                             expiry=NX_LOCKEXPIRY)
         self._path = '/'
@@ -438,7 +440,7 @@ class NXFile(object):
               mode == 'x'):
             if mode == 'w5':
                 mode = 'w'
-            if os.path.exists(self._filename):
+            if Path(self._filename).exists():
                 if mode == 'w-' or mode == 'x':
                     raise NeXusError(f"'{self._filename}' already exists")
                 elif not os.access(self._filename, os.W_OK):
@@ -460,7 +462,7 @@ class NXFile(object):
                 mode = 'r+'
             else:
                 self._mode = 'r'
-            if not os.path.exists(self._filename):
+            if not Path(self._filename).exists():
                 raise NeXusError(f"'{self._filename}' does not exist")
             elif not os.access(self._filename, os.R_OK):
                 raise NeXusError(f"Not permitted to open '{self._filename}'")
@@ -483,7 +485,7 @@ class NXFile(object):
 
     def __repr__(self):
         return (
-          f'<NXFile "{os.path.basename(self._filename)}" mode "{self._mode}">')
+          f'<NXFile "{Path(self._filename).name}" mode "{self._mode}">')
 
     def __getattr__(self, name):
         """Return an attribute of the h5py File if not defined by NXFile"""
@@ -537,7 +539,7 @@ class NXFile(object):
     @property
     def mtime(self):
         """Return the modification time of the NeXus file."""
-        return os.path.getmtime(self._filename)
+        return Path(self._filename).stat().st_mtime
 
     @property
     def lock(self):
@@ -659,7 +661,7 @@ class NXFile(object):
 
     def is_locked(self):
         """Return True if a lock file exists for this NeXus file."""
-        return os.path.exists(self.lock_file)
+        return Path(self.lock_file).exists()
 
     def get(self, *args, **kwargs):
         """Return the value defined by the `h5py` object path."""
@@ -708,7 +710,7 @@ class NXFile(object):
 
     def is_accessible(self):
         """Return True if a lock file exists for this NeXus file."""
-        return os.path.exists(self.lock_file)
+        return Path(self.lock_file).exists()
 
     def readfile(self):
         """Read the NeXus file and return a tree of NeXus objects.
@@ -914,7 +916,7 @@ class NXFile(object):
             _link = self.get(self.nxpath, getlink=True)
             if isinstance(_link, h5.ExternalLink):
                 _target, _filename = _link.path, _link.filename
-                _abspath = os.path.isabs(_filename)
+                _abspath = Path(_filename).is_absolute()
             elif isinstance(_link, h5.SoftLink):
                 _target = _link.path
                 _soft = True
@@ -1085,10 +1087,9 @@ class NXFile(object):
         self.nxpath = self.nxpath + '/' + item.nxname
         if item._abspath:
             filename = item.nxfilename
-        elif os.path.isabs(item._filename):
-            filename = os.path.relpath(
-                os.path.realpath(item._filename),
-                os.path.dirname(os.path.realpath(self.filename)))
+        elif Path(item._filename).is_absolute():
+            filename = os.path.relpath(Path(item._filename),
+                                       Path(self.filename).parent)
         else:
             filename = item._filename
         self[self.nxpath] = self.h5.ExternalLink(filename, item._target)
@@ -2210,8 +2211,8 @@ class NXobject(object):
         >>> root.save()
         """
         if filename:
-            if os.path.splitext(filename)[1] not in ['.nxs', '.nx5', '.h5',
-                                                     '.hdf', '.hdf5', '.cxi']:
+            if Path(filename).suffix not in ['.nxs', '.nx5', '.h5', '.hdf',
+                                             '.hdf5', '.cxi']:
                 filename = filename + '.nxs'
             if self.nxclass == 'NXroot':
                 root = self
@@ -2396,15 +2397,14 @@ class NXobject(object):
         containing the linked data.
         """
         if self._filename is not None:
-            if os.path.isabs(self._filename):
+            if Path(self._filename).is_absolute():
                 return self._filename
             elif (self._group is not None and
                   self._group.nxfilename is not None):
-                return os.path.abspath(
-                    os.path.join(os.path.dirname(self._group.nxfilename),
-                                 self._filename))
+                return str(Path(self._group.nxfilename).parent.joinpath(
+                               self._filename))
             else:
-                return os.path.abspath(self._filename)
+                return str(Path(self._filename).resolve())
         elif self._group is not None:
             return self._group.nxfilename
         else:
@@ -2490,7 +2490,7 @@ class NXobject(object):
     def file_exists(self):
         """True if the file containing the NeXus object exists."""
         if self.nxfilename is not None:
-            return os.path.exists(self.nxfilename)
+            return Path(self.nxfilename).exists()
         else:
             return True
 
@@ -3779,7 +3779,7 @@ class NXfield(NXobject):
         else:
             fname = self.nxfilename
             if fname is not None:
-                return os.path.basename(fname) + ':' + self.nxpath
+                return str(PurePath(fname).name) + ':' + self.nxpath
             else:
                 return self.nxpath
 
@@ -4121,7 +4121,7 @@ class NXfield(NXobject):
         """
         if not self.exists():
             raise NeXusError(
-                    f"'{os.path.abspath(self.nxfilename)}' does not exist")
+                    f"'{Path(self.nxfilename).resolve()}' does not exist")
 
         try:
             from __main__ import plotview
@@ -4211,7 +4211,7 @@ class NXvirtualfield(NXfield):
             target = target.nxfilepath
         self._vpath = target
         if abspath:
-            self._vfiles = [os.path.abspath(f) for f in files]
+            self._vfiles = [Path(f).resolve() for f in files]
         else:
             self._vfiles = files
         if shape:
@@ -4509,19 +4509,19 @@ class NXgroup(NXobject):
     def __getitem__(self, key):
         """Return a NeXus field or group in the current group."""
         if is_text(key):
-            if '/' in key:
-                if key.startswith('/'):
-                    return self.nxroot[key[1:]]
-                names = [name for name in key.split('/') if name]
+            path = PurePath(key)
+            if path.is_absolute():
+                return self.nxroot[key]
+            elif len(path.parts) == 1:
+                return self.entries[key]
+            else:
                 node = self
-                for name in names:
+                for name in path.parts:
                     if name in node:
                         node = node.entries[name]
                     else:
                         raise NeXusError("Invalid path")
                 return node
-            else:
-                return self.entries[key]
         else:
             raise NeXusError("Invalid index")
 
@@ -5169,7 +5169,7 @@ class NXgroup(NXobject):
             else:
                 fname = self.nxfilename
                 if fname is not None:
-                    return os.path.basename(fname) + ':' + self.nxpath
+                    return str(PurePath(fname).name) + ':' + self.nxpath
                 else:
                     return self.nxpath
 
@@ -5348,7 +5348,7 @@ class NXlink(NXobject):
         """Update the NeXus file if necessary."""
         root = self.nxroot
         filename, mode = root.nxfilename, root.nxfilemode
-        if (filename is not None and os.path.exists(filename) and
+        if (filename is not None and Path(filename).exists() and
                 mode == 'rw'):
             with root.nxfile as f:
                 f.update(self)
@@ -5561,7 +5561,7 @@ class NXroot(NXgroup):
     def __repr__(self):
         """Customize display of NXroot when associated with a file."""
         if self.nxfilename:
-            return f"NXroot('{os.path.basename(self.nxfilename)}')"
+            return f"NXroot('{Path(self.nxfilename).stem}')"
         else:
             return f"NXroot('{self.nxname}')"
 
@@ -5612,7 +5612,7 @@ class NXroot(NXgroup):
                 self.set_changed()
             else:
                 raise NeXusError(
-                    f"'{os.path.abspath(self.nxfilename)}' does not exist")
+                    f"'{Path(self.nxfilename).resolve()}' does not exist")
 
     def unlock(self):
         """Make the tree modifiable."""
@@ -5629,7 +5629,7 @@ class NXroot(NXgroup):
                 self._mode = None
                 self._file = None
                 raise NeXusError(
-                    f"'{os.path.abspath(self.nxfilename)}' does not exist")
+                    f"'{Path(self.nxfilename).resolve()}' does not exist")
             self.set_changed()
 
     def backup(self, filename=None, dir=None):
@@ -5648,20 +5648,20 @@ class NXroot(NXgroup):
                 "Only data saved to a NeXus file can be backed up")
         if filename is None:
             if dir is None:
-                dir = os.getcwd()
+                dir = Path.cwd()
             import tempfile
-            prefix, suffix = os.path.splitext(
-                                os.path.basename(self.nxfilename))
+            prefix = Path(self.nxfilename).stem
+            suffix = Path(self.nxfilename).suffix
             prefix = prefix + '_backup_'
             backup = tempfile.mkstemp(prefix=prefix, suffix=suffix, dir=dir)[1]
         else:
             if dir is not None:
-                filename = os.path.join(dir, filename)
-            if os.path.exists(filename):
+                filename = Path(dir).joinpath(filename)
+            if Path(filename).exists():
                 raise NeXusError(
-                    f"'{os.path.abspath(filename)}' already exists")
+                    f"'{Path(filename).resolve()}' already exists")
             else:
-                backup = os.path.abspath(filename)
+                backup = Path(filename).resolve()
         import shutil
         shutil.copy2(self.nxfilename, backup)
         self._backup = backup
@@ -5682,9 +5682,9 @@ class NXroot(NXgroup):
             raise NeXusError("No backup exists")
         if filename is None:
             filename = self.nxfilename
-        if os.path.exists(filename) and not overwrite:
+        if Path(filename).exists() and not overwrite:
             raise NeXusError(
-                f"To overwrite '{os.path.abspath(filename)}', set 'overwite' "
+                f"To overwrite '{Path(filename).resolve()}', set 'overwite' "
                 "to True")
         import shutil
         shutil.copy2(self._backup, filename)
@@ -5747,8 +5747,8 @@ class NXroot(NXgroup):
 
     @nxfile.setter
     def nxfile(self, filename):
-        if os.path.exists(filename):
-            self._filename = os.path.abspath(filename)
+        if Path(filename).exists():
+            self._filename = Path(filename).resolve()
             with NXFile(self._filename, 'r') as f:
                 root = f.readfile()
             self._entries = root._entries
@@ -5758,7 +5758,7 @@ class NXroot(NXgroup):
             self._file = NXFile(self._filename, self._mode)
             self.set_changed()
         else:
-            raise NeXusError(f"'{os.path.abspath(filename)}' does not exist")
+            raise NeXusError(f"'{Path(filename).resolve()}' does not exist")
 
     @property
     def nxbackup(self):
@@ -6955,11 +6955,11 @@ class NXdata(NXgroup):
         if signal is None:
             raise NeXusError("No signal defined for NXdata group")
         else:
-            if ('uncertainties' in signal.attrs and
+            if signal.nxname+'_errors' in self:
+                errors = self[signal.nxname+'_errors']
+            elif ('uncertainties' in signal.attrs and
                     signal.attrs['uncertainties'] in self):
                 errors = self[signal.attrs['uncertainties']]
-            elif signal.nxname+'_errors' in self:
-                errors = self[signal.nxname+'_errors']
             elif 'errors' in self:
                 errors = self['errors']
             if errors and errors.shape == signal.shape:


### PR DESCRIPTION
* Uses the Python `pathlib` package to resolve external filenames.
* Uses the Python `pathlib` package for parsing Posix-compliant paths within NeXus files.
* Makes lock files accessible to all users. 