### PR TITLE
Set up lock directories

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,10 +1,10 @@
 package:
   name: nexusformat
-  version: "0.7.4"
+  version: "0.7.8"
 
 source:
   git_url: https://github.com/nexpy/nexusformat.git
-  git_tag: v0.7.4
+  git_tag: v0.7.8
 
 build:
   entry_points:

--- a/src/nexusformat/nexus/lock.py
+++ b/src/nexusformat/nexus/lock.py
@@ -167,6 +167,8 @@ class NXLock(object):
     @property
     def locked(self):
         """Return True if the current process has locked the file."""
+        if not self.lock_file.exists():
+            self.fd = None
         return self.fd is not None
 
     def clear(self):

--- a/src/nexusformat/nexus/lock.py
+++ b/src/nexusformat/nexus/lock.py
@@ -15,6 +15,8 @@ import os
 import time
 import timeit
 
+from .tree import nxgetlock, nxgetlockdirectory
+
 
 class NXLockException(Exception):
     LOCK_FAILED = 1
@@ -34,7 +36,8 @@ class NXLock(object):
         File descriptor of the opened lock file.
     """
 
-    def __init__(self, filename, timeout=60, check_interval=1):
+    def __init__(self, filename, timeout=None, check_interval=1,
+                 directory=None):
         """Create a lock to prevent file access.
 
         This creates a lock, which can be later acquired and released. It
@@ -51,11 +54,24 @@ class NXLock(object):
         check_interval : int, optional
             Number of seconds between attempts to acquire the lock,
             by default 1.
+        directory : str, optional
+            Path to directory to contain lock file paths.
         """
         self.filename = os.path.realpath(filename)
-        self.lock_file = self.filename+'.lock'
+        if timeout is None:
+            timeout = nxgetlock()
         self.timeout = timeout
         self.check_interval = check_interval
+        if directory is None:
+            directory = nxgetlockdirectory()
+        if directory:
+            directory = os.path.join(
+                directory, os.path.dirname(self.filename)[1:])
+            os.makedirs(self.directory)
+            self.lock_file = os.path.join(
+                directory, os.path.basename(self.filename+'.lock'))
+        else:
+            self.lock_file = self.filename+'.lock'
         self.pid = os.getpid()
         self.fd = None
 

--- a/src/nexusformat/nexus/lock.py
+++ b/src/nexusformat/nexus/lock.py
@@ -60,17 +60,17 @@ class NXLock(object):
         directory : str, optional
             Path to directory to contain lock file paths.
         """
-        from .tree import nxgetlock, nxgetlockdirectory
+        from .tree import nxgetconfig
 
         self.filename = Path(filename).resolve()
         suffix = self.filename.suffix + '.lock'
         if timeout is None:
-            timeout = nxgetlock()
+            timeout = nxgetconfig('lock')
         self.timeout = timeout
         self.check_interval = check_interval
         self.expiry = expiry
         if directory is None:
-            directory = nxgetlockdirectory()
+            directory = nxgetconfig('lockdirectory')
         if directory:
             try:
                 directory = Path(directory).resolve(strict=True)

--- a/src/nexusformat/nexus/lock.py
+++ b/src/nexusformat/nexus/lock.py
@@ -12,6 +12,7 @@
 
 import errno
 import os
+import socket
 import time
 import timeit
 
@@ -73,12 +74,11 @@ class NXLock(object):
         else:
             self.lock_file = self.filename+'.lock'
         self.pid = os.getpid()
+        self.addr = f"{self.pid}@{socket.gethostname}"
         self.fd = None
 
     def __repr__(self):
-        return ("NXLock('"
-                + os.path.basename(self.filename)
-                + "', pid=" + str(self.pid)+")")
+        return f"NXLock('{os.path.basename(self.filename)}', pid={self.addr})"
 
     def acquire(self, timeout=None, check_interval=None):
         """Acquire the lock.
@@ -113,7 +113,7 @@ class NXLock(object):
                 # then someone else has the lock and we need to wait
                 self.fd = os.open(self.lock_file, os.O_CREAT |
                                   os.O_EXCL | os.O_RDWR)
-                open(self.lock_file, 'w').write(str(self.pid))
+                open(self.lock_file, 'w').write(self.addr)
                 break
             except OSError as e:
                 # Only catch if the lockfile already exists

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -190,6 +190,7 @@ __all__ = ['NXFile', 'NXobject', 'NXfield', 'NXgroup', 'NXattr',
            'NeXusError',
            'nxgetcompression', 'nxsetcompression',
            'nxgetencoding', 'nxsetencoding', 'nxgetlock', 'nxsetlock',
+           'nxgetlockdirectory', 'nxsetlockdirectory',
            'nxgetmaxsize', 'nxsetmaxsize', 'nxgetmemory', 'nxsetmemory',
            'nxgetrecursive', 'nxsetrecursive',
            'nxclasses', 'nxload', 'nxsave', 'nxduplicate', 'nxdir',
@@ -213,6 +214,7 @@ warnings.simplefilter('ignore', category=FutureWarning)
 NX_COMPRESSION = 'gzip'
 NX_ENCODING = 'utf-8'
 NX_LOCK = 0
+NX_LOCKDIRECTORY = None
 NX_MAXSIZE = 10000
 NX_MEMORY = 2000  # Memory in MB
 NX_RECURSIVE = False
@@ -584,7 +586,7 @@ class NXFile(object):
     def lock_file(self):
         """Return the name of the file used to establish the lock."""
         if self._lock is None:
-            self._lock = NXLock(self._filename, timeout=NX_LOCK)
+            self._lock = NXLock(self._filename)
         return self._lock.lock_file
 
     def acquire_lock(self, timeout=None):
@@ -7149,6 +7151,39 @@ def setlock(value=10):
 
 nxgetlock = getlock
 nxsetlock = setlock
+
+
+def getlockdirectory():
+    """Return the path to the lock directory.
+
+    If the value is None, lock files are stored in the same directory as
+    the file.
+
+    Returns
+    -------
+    str
+        Path to the lock directory.
+    """
+    return NX_LOCKDIRECTORY
+
+
+def setlockdirectory(value):
+    """Define a directory to store lock files.
+
+    If the value is None, lock files are stored in the same directory as
+    the file.
+
+    Parameters
+    ----------
+    value : str, optional
+        Path to the lock directory.
+    """
+    global NX_LOCKDIRECTORY
+    NX_LOCKDIRECTORY = value
+
+
+nxgetlockdirectory = getlockdirectory
+nxsetlockdirectory = setlockdirectory
 
 
 def getmaxsize():

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -189,10 +189,12 @@ __all__ = ['NXFile', 'NXobject', 'NXfield', 'NXgroup', 'NXattr',
            'NXvirtualfield', 'NXlink', 'NXlinkfield', 'NXlinkgroup',
            'NeXusError',
            'nxgetcompression', 'nxsetcompression',
-           'nxgetencoding', 'nxsetencoding', 'nxgetlock', 'nxsetlock',
-           'nxgetlockdirectory', 'nxsetlockdirectory',
+           'nxgetencoding', 'nxsetencoding',
+           'nxgetlock', 'nxsetlock',
            'nxgetlockexpiry', 'nxsetlockexpiry',
-           'nxgetmaxsize', 'nxsetmaxsize', 'nxgetmemory', 'nxsetmemory',
+           'nxgetlockdirectory', 'nxsetlockdirectory',
+           'nxgetmaxsize', 'nxsetmaxsize',
+           'nxgetmemory', 'nxsetmemory',
            'nxgetrecursive', 'nxsetrecursive',
            'nxclasses', 'nxload', 'nxopen', 'nxsave', 'nxduplicate', 'nxdir',
            'nxconsolidate', 'nxdemo', 'nxversion']
@@ -4524,7 +4526,7 @@ class NXgroup(NXobject):
                 node = node.entries[name]
             except KeyError:
                 raise NeXusError("Invalid path")
-        return node            
+        return node
 
     def __setitem__(self, key, value):
         """Add or modify entries to the group dictionary.
@@ -7353,6 +7355,7 @@ def setlockdirectory(value):
         Path to the lock directory.
     """
     global NX_LOCKDIRECTORY
+    value = Path(value).resolve(strict=True)
     NX_LOCKDIRECTORY = value
 
 

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1,7 +1,7 @@
 import h5py as h5
 import numpy as np
 import pytest
-from nexusformat.nexus.tree import NXfield, nxgetencoding
+from nexusformat.nexus.tree import NXfield, nxgetconfig
 
 
 @pytest.fixture
@@ -32,7 +32,7 @@ def test_byte_field_creation(text, string_dtype):
     field = NXfield(text, dtype='S')
 
     assert field.nxvalue == text
-    assert field.nxdata.decode(nxgetencoding()) == text
+    assert field.nxdata.decode(nxgetconfig('encoding')) == text
     assert field.dtype != string_dtype
     assert field.is_string()
     assert len(field) == len(text)

--- a/tests/test_locks.py
+++ b/tests/test_locks.py
@@ -3,12 +3,12 @@ import time
 
 import pytest
 from nexusformat.nexus.tree import (NeXusError, NXentry, NXLock, NXroot,
-                                    nxload, nxsetlock, nxsetlockexpiry, text)
+                                    nxload, nxsetconfig, text)
 
 
 def test_lock_creation(tmpdir, field4):
 
-    nxsetlock(0)
+    nxsetconfig(lock=0)
     filename = os.path.join(tmpdir, "file1.nxs")
     root = NXroot(NXentry(field4))
     root.save(filename)
@@ -90,7 +90,7 @@ def test_lock_interactions(tmpdir, field4):
 
 def test_lock_defaults(tmpdir, field4):
 
-    nxsetlock(20)
+    nxsetconfig(lock=20)
     filename = os.path.join(tmpdir, "file1.nxs")
     root = NXroot(NXentry(field4))
     root.save(filename, "w")
@@ -105,7 +105,7 @@ def test_lock_defaults(tmpdir, field4):
     assert not root.nxfile.locked
     assert not root.nxfile.is_locked()
 
-    nxsetlock(0)
+    nxsetconfig(lock=0)
     root = NXroot(NXentry(field4))
     root.save(filename, "w")
 
@@ -150,8 +150,7 @@ def test_nested_locks(tmpdir, field4):
 
 def test_stale_locks(tmpdir):
 
-    nxsetlock(2)
-    nxsetlockexpiry(3600)
+    nxsetconfig(lock=2, lockexpiry=3600)
     filename = os.path.join(tmpdir, "file1.nxs")
     root = NXroot(NXentry())
     root.save(filename, "w")


### PR DESCRIPTION
* Sets up the `NX_CONFIG` dictionary to store configuration parameters.
* Reads environment variables to initialize configuration parameters.
* Allows lock files to be stored in a single directory when `NX_CONFIG['lockdirectory']` is defined.