### PR TITLE
Ensure all Path filenames are converted to strings

### DIFF
--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -2402,7 +2402,7 @@ class NXobject(object):
         """
         if self._filename is not None:
             if Path(self._filename).is_absolute():
-                return self._filename
+                return str(self._filename)
             elif (self._group is not None and
                   self._group.nxfilename is not None):
                 return str(Path(self._group.nxfilename).parent.joinpath(


### PR DESCRIPTION
* Fixes the output of `nxfilename` in some cases.