### PR TITLE
Update-classes

### DIFF
--- a/src/nexusformat/nexus/lock.py
+++ b/src/nexusformat/nexus/lock.py
@@ -22,7 +22,7 @@ class NXLockException(Exception):
     LOCK_FAILED = 1
 
 
-class NXLock(object):
+class NXLock:
     """Class for acquiring and releasing file-based locks.
 
     Attributes

--- a/src/nexusformat/nexus/plot.py
+++ b/src/nexusformat/nexus/plot.py
@@ -96,7 +96,7 @@ def label(field):
         return field.nxname
 
 
-class PylabPlotter:
+class PyplotPlotter:
     """Matplotlib plotter class for 1D or 2D NeXus data.
 
     When the nexusformat package is used within NeXpy, plots are produced by
@@ -326,4 +326,4 @@ class PylabPlotter:
                 plt.ion()
 
 
-plotview = PylabPlotter()
+plotview = PyplotPlotter()

--- a/src/nexusformat/nexus/plot.py
+++ b/src/nexusformat/nexus/plot.py
@@ -96,7 +96,7 @@ def label(field):
         return field.nxname
 
 
-class PylabPlotter(object):
+class PylabPlotter:
     """Matplotlib plotter class for 1D or 2D NeXus data.
 
     When the nexusformat package is used within NeXpy, plots are produced by

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -364,7 +364,7 @@ class NeXusError(Exception):
     pass
 
 
-class NXFile(object):
+class NXFile:
     """Interface for input/output to NeXus files using h5py.
 
     Usage::
@@ -1808,7 +1808,7 @@ class AttrDict(dict):
         return self._parent.nxpath
 
 
-class NXattr(object):
+class NXattr:
     """Class for NeXus attributes of a NXfield or NXgroup object.
 
     Attributes
@@ -1932,7 +1932,7 @@ class NXattr(object):
 _npattrs = list(filter(lambda x: not x.startswith('_'), np.ndarray.__dict__))
 
 
-class NXobject(object):
+class NXobject:
 
     """Abstract base class for elements in NeXus files.
 


### PR DESCRIPTION
* Removes remnants of PY2 class inheritance
* Renames PylabPlotter to PyplotPlotter, since Pylab is no longer supported.