### PR TITLE
Tweak use of pathlib

### DIFF
--- a/src/nexusformat/nexus/lock.py
+++ b/src/nexusformat/nexus/lock.py
@@ -210,7 +210,7 @@ class NXLock:
         NXLockException
             If lock not cleared before `timeout`.
         """
-        if os.path.exists(self.lock_file):
+        if self.lock_file.exists():
             if timeout is None:
                 timeout = self.timeout
             if check_interval is None:
@@ -218,7 +218,7 @@ class NXLock:
             timeoutend = timeit.default_timer() + timeout
             while timeoutend > timeit.default_timer():
                 time.sleep(check_interval)
-                if not os.path.exists(self.lock_file):
+                if not self.lock_file.exists():
                     break
             else:
                 raise NXLockException(f"'{self.filename}' is currently locked "
@@ -234,7 +234,7 @@ class NXLock:
         if expiry is None:
             expiry = self.expiry
         try:
-            return ((time.time() - os.path.getmtime(self.lock_file)) > expiry)
+            return ((time.time() - self.lock_file.stat().st_mtime) > expiry)
         except FileNotFoundError:
             return False
 

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -2225,9 +2225,9 @@ class NXobject:
         >>> root.save()
         """
         if filename:
-            if Path(filename).suffix not in ['.nxs', '.nx5', '.h5', '.hdf',
-                                             '.hdf5', '.cxi']:
-                filename = filename + '.nxs'
+            filename = Path(filename)
+            if filename.suffix == '':
+                filename = filename.with_suffix('.nxs')
             if self.nxclass == 'NXroot':
                 root = self
             elif self.nxclass == 'NXentry':
@@ -7567,7 +7567,7 @@ def save(filename, group, mode='w', **kwargs):
 
     Parameters
     ----------
-    filename : str
+    filename : str or Path
         Name of the file to be saved.
     group : NXgroup
         Group containing the tree to be saved.

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -1502,6 +1502,8 @@ def _getvalue(value, dtype=None, shape=None):
     dtype, shape = _getdtype(dtype), _getshape(shape)
     if isinstance(value, NXfield) or isinstance(value, NXattr):
         value = value.nxvalue
+    elif isinstance(value, Path):
+        value = str(value)
     if value is None:
         return None, dtype, shape
     elif is_text(value):
@@ -5250,7 +5252,7 @@ class NXlink(NXobject):
         self._soft = soft
         self._entries = None
         if file is not None:
-            self._filename = file
+            self._filename = str(file)
             self._mode = 'r'
         else:
             self._filename = self._mode = None

--- a/tests/test_links.py
+++ b/tests/test_links.py
@@ -199,7 +199,8 @@ def test_external_group_links(tmpdir, field1a, save):
     assert root["entry/g1_link"].path_exists()
 
     assert "f1" in root["entry/g1_link"]
-    assert root["entry/g1_link/f1"].nxfilename == root["entry/g1_link"].nxfilename
+    assert root["entry/g1_link/f1"].nxfilename == (
+        root["entry/g1_link"].nxfilename)
     assert root["entry/g1_link/f1"].nxfilepath == "/entry/g1/f1"
     assert root["entry/g1_link/f1"].nxroot == root
     assert root["entry/g1_link/f1"].nxgroup is root["entry/g1_link"]


### PR DESCRIPTION
* Allows Path objects to be stored in NXfields after conversion to strings.
* Allows Path objects to be used to define externally linked files.
* Fixes a bug when saving files with unsupported extensions.
* Uses pathlib in discovering files in the `nxstack` script.