### PR TITLE
Pass keyword arguments to `NXfield.__array__`

### DIFF
--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -3278,11 +3278,11 @@ class NXfield(NXobject):
                 pass
         return int(np.clip(idx, 0, len(self.nxdata)-1))
 
-    def __array__(self, **kwargs):
+    def __array__(self, *args, **kwargs):
         """Cast the NXfield as a NumPy array."""
-        return np.asarray(self.nxdata, **kwargs)
+        return np.asarray(self.nxdata, *args, **kwargs)
 
-    def __array_wrap__(self, value, **kwargs):
+    def __array_wrap__(self, value, context=None):
         """Transform the array resulting from a ufunc to an NXfield."""
         return NXfield(value, name=self.nxname)
 

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -3278,11 +3278,11 @@ class NXfield(NXobject):
                 pass
         return int(np.clip(idx, 0, len(self.nxdata)-1))
 
-    def __array__(self):
+    def __array__(self, **kwargs):
         """Cast the NXfield as a NumPy array."""
-        return np.asarray(self.nxdata)
+        return np.asarray(self.nxdata, **kwargs)
 
-    def __array_wrap__(self, value):
+    def __array_wrap__(self, value, **kwargs):
         """Transform the array resulting from a ufunc to an NXfield."""
         return NXfield(value, name=self.nxname)
 

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -149,3 +149,18 @@ def test_field_operations(peak1D):
     assert np.isclose(peak1D.moment(2), 100.0, rtol=1e-3)
     assert np.isclose(peak1D.std(), 10.0, rtol=1e-3)
     assert np.isclose(peak1D.average(), peak1D.nxvalue.sum() / 101.0)
+
+
+@pytest.mark.parametrize(
+    "arr",
+    ["arr1D",
+     "arr2D",
+     "arr3D"])
+def test_numpy_conversion(arr, request):
+
+    arr = request.getfixturevalue(arr)
+    field = NXfield(arr)
+
+    assert np.array_equal(field, arr)
+    assert np.array_equal(np.array(field, dtype=np.float32), 
+                          arr.astype(np.float32))


### PR DESCRIPTION
Prevents an exception when additional keyword arguments are used in the NumPy `array` function, e.g., to set the datatyle.