### PR TITLE
Ensure locks are released when initializing NXFile

### DIFF
--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -487,11 +487,12 @@ class NXFile:
                 self.acquire_lock()
                 self._file = self.h5.File(self._filename, mode, **kwargs)
                 self._file.close()
-                self.release_lock()
             except NeXusError as error:
                 raise error
             except Exception as error:
                 raise NeXusError(str(error))
+            finally:
+                self.release_lock()
 
     def __repr__(self):
         return (


### PR DESCRIPTION
* Releases the lock, even if an exception is raised by calling
h5.File. This can happen when opened for read/write access when another
(non-nexusformat) process has already opened it or because of a race
condition.