### PR TITLE
Fix-ipython-calltips

### DIFF
--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -485,7 +485,7 @@ class NXFile:
                   f"Not permitted to create a lock file in '{self._lockdir}'")
             try:
                 self.acquire_lock()
-                self._file = self.h5.File(self._filename, 'r', **kwargs)
+                self._file = self.h5.File(self._filename, mode, **kwargs)
                 self._file.close()
             except NeXusError as error:
                 raise error
@@ -5285,7 +5285,8 @@ class NXlink(NXobject):
         try:
             return getattr(self.nxlink, name)
         except Exception:
-            raise AttributeError(f"Cannot resolve the link to '{self._target}'")
+            raise AttributeError(
+                f"Cannot resolve the link to '{self._target}'")
 
     def __setattr__(self, name, value):
         """Set an attribute of the link target.

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -4488,7 +4488,7 @@ class NXgroup(NXobject):
             return self.entries[name]
         elif name in self.attrs:
             return self.attrs[name]
-        raise NeXusError("'"+name+"' not in "+self.nxpath)
+        raise AttributeError("'"+name+"' not in "+self.nxpath)
 
     def __setattr__(self, name, value):
         """Set an attribute as an object or regular Python attribute.
@@ -5285,7 +5285,7 @@ class NXlink(NXobject):
         try:
             return getattr(self.nxlink, name)
         except Exception:
-            raise NeXusError(f"Cannot resolve the link to '{self._target}'")
+            raise AttributeError(f"Cannot resolve the link to '{self._target}'")
 
     def __setattr__(self, name, value):
         """Set an attribute of the link target.

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -485,7 +485,7 @@ class NXFile:
                   f"Not permitted to create a lock file in '{self._lockdir}'")
             try:
                 self.acquire_lock()
-                self._file = self.h5.File(self._filename, mode, **kwargs)
+                self._file = self.h5.File(self._filename, 'r', **kwargs)
                 self._file.close()
             except NeXusError as error:
                 raise error


### PR DESCRIPTION
* Fixes an issue caused by changes in call tip display code introduced in IPython 8.12.
* Changes the raised error class in `__getattr__` from `NeXusError` to `AttributeError` in conformance with Python documentation.