### PR TITLE
Fix-weighted-data

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,13 +6,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         os: [ubuntu-latest, macOS-latest, windows-latest]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,10 +1,10 @@
 package:
   name: nexusformat
-  version: "1.0.4"
+  version: "1.0.5"
 
 source:
   git_url: https://github.com/nexpy/nexusformat.git
-  git_tag: v1.0.4
+  git_tag: v1.0.5
 
 build:
   entry_points:

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -6395,6 +6395,7 @@ class NXdata(NXgroup):
             raise NeXusError("No signal defined for this NXdata group")
         elif weights is None:
             raise NeXusError("No weights defined for this NXdata group")
+        result._group = self._group
         return result
 
     def prepare_smoothing(self):


### PR DESCRIPTION
* Adds the parent group of the original NXdata group to the returned result.
* This improves plot labelling in NeXpy.
* Updates Github actions to exclude Python v3.7 and add Python 3.12. In principle, the package works with Python 3.7, but Github actions no longer support it on some operating systems.