### PR TITLE
Fix NumPy 2.x compatibility: replace `np.string_` with `np.bytes_`

### DIFF
--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -3280,7 +3280,7 @@ class NXfield(NXobject):
         """Cast the NXfield as a NumPy array."""
         return np.asarray(self.nxdata, *args, **kwargs)
 
-    def __array_wrap__(self, value, context=None):
+    def __array_wrap__(self, value, context=None, return_scalar=False):
         """Transform the array resulting from a ufunc to an NXfield."""
         return NXfield(value, name=self.nxname)
 

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -1864,7 +1864,7 @@ class NXattr:
     def __repr__(self):
         if (self.dtype is not None and
             (self.shape == () or self.shape == (1,)) and
-            (self.dtype.type == np.string_ or self.dtype.type == np.str_ or
+            (self.dtype.type == np.bytes_ or self.dtype.type == np.str_ or
              self.dtype == string_dtype)):
             return f"NXattr('{self}')"
         else:
@@ -1898,7 +1898,7 @@ class NXattr:
         if self._value is None:
             return ''
         elif (self.dtype is not None and
-              (self.dtype.type == np.string_ or self.dtype.type == np.str_ or
+              (self.dtype.type == np.bytes_ or self.dtype.type == np.str_ or
                self.dtype == string_dtype)):
             if self.shape == ():
                 return text(self._value)
@@ -3721,7 +3721,7 @@ class NXfield(NXobject):
         if _value is None:
             return None
         elif (self.dtype is not None and
-              (self.dtype.type == np.string_ or self.dtype.type == np.str_ or
+              (self.dtype.type == np.bytes_ or self.dtype.type == np.str_ or
                self.dtype == string_dtype)):
             if self.shape == ():
                 return text(_value)


### PR DESCRIPTION
NumPy v2.0 removed `np.string_` from the API and recommended using `np.bytes_` instead, so I made that change. Since `np.string_` was already an alias for `np.bytes_`, I think this is backward compatible with recent versions Numpy v1.x. At least test suite passes with both NumPy 2.0.0 and NumPy 1.26.4.

I checked the other API removals in the [NumPy v2.0.0 release notes](https://numpy.org/doc/stable/release/2.0.0-notes.html#numpy-2-0-python-api-removals) and didn't see any other instances of removed NumPy objects in the nexusformat codebase.

Without this change, some of my previously-working code that checked for certain entries in a `nxs.tree.NXdata.attrs` dictionary was failing.