### PR TITLE
Fix-soft-links

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -37,7 +37,7 @@ About the NeXpy Development Team
 ----------------------------------
 
 The NeXpy Development Team is the set of all contributors to the NeXpy
-project on the Github at https://github.com/nexpy/nexpy. The project is
+project on the Github at https://github.com/nexpy. The project is
 currently led by Ray Osborn.
 
 Copyright
@@ -47,7 +47,7 @@ The following banner should be used in any source code file to indicate the
 copyright and license terms:
 
 # -----------------------------------------------------------------------------
-# Copyright (c) 2014-2021, NeXpy Development Team.
+# Copyright (c) 2014-2024, NeXpy Development Team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -5271,8 +5271,6 @@ class NXlink(NXobject):
             if name is None and is_text(target):
                 self._name = target.rsplit('/', 1)[1]
             self._target = text(target)
-            if not self._target.startswith('/'):
-                self._target = '/' + self._target
         self._link = None
 
     def __repr__(self):
@@ -5422,7 +5420,13 @@ class NXlink(NXobject):
     @property
     def internal_link(self):
         """Return NXfield or NXgroup targeted by an internal link."""
-        return self.nxroot[self._target]
+        if Path(self._target).is_absolute():
+            return self.nxroot[self._target]
+        else:
+            try:
+                return self.nxgroup[self._target]
+            except NeXusError:
+                return self.nxroot[self._target]
 
     @property
     def external_link(self):

--- a/tests/test_links.py
+++ b/tests/test_links.py
@@ -238,3 +238,36 @@ def test_external_group_files(tmpdir, field1a):
         assert not root["entry/g1_link"].nxfile.locked
 
     assert not root.nxfile.locked
+
+@pytest.mark.parametrize("save", ["False", "True"])
+def test_soft_field_links(tmpdir, field1a, field2a,save):
+
+    root = NXroot()
+    root["g1"] = NXgroup()
+    root["g1/g2"] = NXgroup(f1=field1a, f2=field2a)
+    root["g1"].f1_link = NXlink(target="g2/f1", soft=True)
+    root["g1"].f2_link = NXlink(target="g1/g2/f2", soft=True)
+
+    if save:
+        filename = os.path.join(tmpdir, "file1.nxs")
+        root.save(filename, mode="w")
+
+    assert root["g1/f1_link"].shape == (2,)
+    assert root["g1/f1_link"].dtype == np.float32
+
+    root["g1/g2/f1"].attrs["a1"] = 1
+
+    assert "a1" in root["g1/f1_link"].attrs
+    assert root["g1/f1_link"].a1 == 1
+
+    assert root["g1/f1_link"].nxdata[0] == root["g1/g2/f1"].nxdata[0]
+
+    assert root["g1/f2_link"].shape == (2,)
+    assert root["g1/f2_link"].dtype == np.int16
+
+    root["g1/g2/f2"].attrs["a2"] = 2
+
+    assert "a2" in root["g1/f2_link"].attrs
+    assert root["g1/f2_link"].a2 == 2
+
+    assert root["g1/f2_link"].nxdata[0] == root["g1/g2/f2"].nxdata[0]


### PR DESCRIPTION
* Allows the use of relative paths in links. The target path is relative to the containing group.
* For backward compatibility, a target path relative to the root object will be tried if the path relative to the group cannot be resolved. Ideally, such paths should be specified as absolute. 