### PR TITLE
Add-numpy-kwargs

### DIFF
--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -3446,15 +3446,15 @@ class NXfield(NXobject):
         return NXfield(value=pow(self.nxdata, power), name=self.nxname,
                        attrs=self.safe_attrs)
 
-    def min(self, axis=None):
+    def min(self, axis=None, **kwargs):
         """Return the minimum value of the array ignoring NaNs."""
-        return np.nanmin(self.nxdata[self.nxdata > -np.inf], axis)
+        return np.nanmin(self.nxdata[self.nxdata > -np.inf], axis, **kwargs)
 
-    def max(self, axis=None):
+    def max(self, axis=None, **kwargs):
         """Return the maximum value of the array ignoring NaNs."""
-        return np.nanmax(self.nxdata[self.nxdata < np.inf], axis)
+        return np.nanmax(self.nxdata[self.nxdata < np.inf], axis, **kwargs)
 
-    def sum(self, axis=None):
+    def sum(self, axis=None, **kwargs):
         """Return the sum of NXfield values.
 
         Parameters
@@ -3468,9 +3468,9 @@ class NXfield(NXobject):
             Summed values.
         """
         return NXfield(np.sum(self.nxdata, axis), name=self.nxname,
-                       attrs=self.safe_attrs)
+                       attrs=self.safe_attrs, **kwargs)
 
-    def average(self, axis=None):
+    def average(self, axis=None, **kwargs):
         """Return the average of NXfield values.
 
         Parameters
@@ -3483,8 +3483,8 @@ class NXfield(NXobject):
         NXfield
             Averaged values.
         """
-        return NXfield(np.average(self.nxdata, axis), name=self.nxname,
-                       attrs=self.safe_attrs)
+        return NXfield(np.average(self.nxdata, axis, **kwargs),
+                       name=self.nxname, attrs=self.safe_attrs)
 
     def moment(self, order=1, center=None):
         """Return the central moments of a one-dimensional field.

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -83,6 +83,7 @@ def test_field_methods(arr, request):
     arr = request.getfixturevalue(arr)
     field = NXfield(arr)
 
+    assert np.array_equal(field**2, arr**2)
     assert field.min() == np.min(arr)
     assert field.min(keepdims=True) == np.min(arr, keepdims=True)
     assert field.max() == np.max(arr)

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -83,7 +83,14 @@ def test_field_methods(arr, request):
     arr = request.getfixturevalue(arr)
     field = NXfield(arr)
 
+    assert field.min() == np.min(arr)
+    assert field.min(keepdims=True) == np.min(arr, keepdims=True)
+    assert field.max() == np.max(arr)
+    assert field.max(keepdims=True) == np.max(arr, keepdims=True)
     assert field.sum() == np.sum(arr)
+    assert field.sum(dtype=np.float32) == np.sum(arr, dtype=np.float32)
+    assert field.average() == np.average(arr)
+    assert field.average(keepdims=True) == np.average(arr, keepdims=True)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
* Enables the addition of NumPy keyword arguments to the NXfield methods, such as `sum`, `average`, `min`, and `max`.