### PR TITLE
Fix-tests

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,6 +35,7 @@ install_requires =
     scipy
     h5py >=2.9
     hdf5plugin
+    packaging
 
 [options.packages.find]
 where = src

--- a/src/nexusformat/nexus/plot.py
+++ b/src/nexusformat/nexus/plot.py
@@ -1,5 +1,5 @@
 # -----------------------------------------------------------------------------
-# Copyright (c) 2013-2021, NeXpy Development Team.
+# Copyright (c) 2013-2025, NeXpy Development Team.
 #
 # Author: Paul Kienzle, Ray Osborn
 #
@@ -12,6 +12,7 @@
 import copy
 
 import numpy as np
+from packaging.version import Version
 
 from . import NeXusError, NXfield
 
@@ -252,8 +253,7 @@ class PyplotPlotter:
                     else:
                         kwargs["norm"] = Normalize(vmin, vmax)
 
-                    from pkg_resources import parse_version as pv
-                    if pv(mplversion) >= pv('3.5.0'):
+                    if Version(mplversion) >= Version('3.5.0'):
                         from matplotlib import colormaps
                         cm = copy.copy(colormaps[cmap])
                     else:
@@ -292,7 +292,7 @@ class PyplotPlotter:
                                     im.set_clim(-0.5, 9.5)
                                 elif cmin == 1:
                                     im.set_clim(0.5, 10.5)
-                                if pv(mplversion) >= pv('3.5.0'):
+                                if Version(mplversion) >= Version('3.5.0'):
                                     cb.ax.set_ylim(cmin-0.5, cmax+0.5)
                                     cb.set_ticks(range(int(cmin), int(cmax)+1))
 

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1,6 +1,9 @@
+import sys
+
 import h5py as h5
 import numpy as np
 import pytest
+
 from nexusformat.nexus.tree import NXfield, nxgetconfig
 
 
@@ -85,13 +88,14 @@ def test_field_methods(arr, request):
 
     assert np.array_equal(field**2, arr**2)
     assert field.min() == np.min(arr)
-    assert field.min(keepdims=True) == np.min(arr, keepdims=True)
     assert field.max() == np.max(arr)
-    assert field.max(keepdims=True) == np.max(arr, keepdims=True)
     assert field.sum() == np.sum(arr)
     assert field.sum(dtype=np.float32) == np.sum(arr, dtype=np.float32)
     assert field.average() == np.average(arr)
-    assert field.average(keepdims=True) == np.average(arr, keepdims=True)
+    if sys.version_info >= (3, 8):
+        assert field.min(keepdims=True) == np.min(arr, keepdims=True)
+        assert field.max(keepdims=True) == np.max(arr, keepdims=True)
+        assert field.average(keepdims=True) == np.average(arr, keepdims=True)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
* Removes tests that fail under Python 3.6 and 3.7. These use NumPy keyword arguments so the documentation will be updated to state that they are not supported in older Python versions.
* Uses the `packaging` module to perform version comparisons.