### PR TITLE
Add-softlink-target

### DIFF
--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -1125,6 +1125,7 @@ class NXFile:
                     and target in self['/']):
                 if soft:
                     self[path] = h5.SoftLink(target)
+                    self[target].attrs['target'] = target
                 else:
                     if 'target' not in self[target].attrs:
                         self[target].attrs['target'] = target

--- a/tests/test_links.py
+++ b/tests/test_links.py
@@ -245,8 +245,8 @@ def test_soft_field_links(tmpdir, field1a, field2a,save):
     root = NXroot()
     root["g1"] = NXgroup()
     root["g1/g2"] = NXgroup(f1=field1a, f2=field2a)
-    root["g1"].f1_link = NXlink(target="g2/f1", soft=True)
-    root["g1"].f2_link = NXlink(target="g1/g2/f2", soft=True)
+    root["g1/f1_link"] = NXlink(target="g2/f1", soft=True)
+    root["g1/f2_link"] = NXlink(target="g1/g2/f2", soft=True)
 
     if save:
         filename = os.path.join(tmpdir, "file1.nxs")


### PR DESCRIPTION
* Adds the `target` attribute when creating a new soft link to better conform to the NeXus standard.
* Fix the relevant pytest function.