### PR TITLE
Fix 'doc' elements in symbol tables

### DIFF
--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -213,7 +213,7 @@ import numpy as np
 
 from .. import __version__ as nxversion
 from .lock import NXLock, NXLockException
-from .utils import get_classes
+from .utils import get_base_classes
 
 warnings.simplefilter('ignore', category=FutureWarning)
 
@@ -224,7 +224,7 @@ NX_CONFIG = {'compression': 'gzip', 'definitions': None, 'encoding': 'utf-8',
 # These are overwritten below by environment variables if defined.
 
 # List of NeXus base classes
-nxclasses = get_classes()
+nxclasses = get_base_classes()
 
 
 string_dtype = h5.special_dtype(vlen=str)

--- a/src/nexusformat/nexus/utils.py
+++ b/src/nexusformat/nexus/utils.py
@@ -454,7 +454,7 @@ def match_strings(pattern_string, target_string):
     return False
 
 
-def get_classes(definitions=None):
+def get_base_classes(definitions=None):
     """
     Return a list of all base class names.
 

--- a/src/nexusformat/nexus/utils.py
+++ b/src/nexusformat/nexus/utils.py
@@ -347,7 +347,7 @@ def xml_to_dict(element):
 
     for child in element:
         if child.tag == 'doc':
-            continue
+            result[child.tag] = re.sub(r'[\t\n]+', ' ', child.text.strip())
         elif child.tag == 'enumeration':
             result[child.tag] = [item.attrib['value'] for item in child]
         elif child.tag == 'dimensions':

--- a/src/nexusformat/nexus/utils.py
+++ b/src/nexusformat/nexus/utils.py
@@ -346,7 +346,7 @@ def xml_to_dict(element):
             result[f"@{attr}"] = attrs[attr]
 
     for child in element:
-        if child.tag == 'doc':
+        if child.tag == 'doc' and child.text:
             result[child.tag] = re.sub(r'[\t\n]+', ' ', child.text.strip())
         elif child.tag == 'enumeration':
             result[child.tag] = [item.attrib['value'] for item in child]

--- a/src/nexusformat/nexus/validate.py
+++ b/src/nexusformat/nexus/validate.py
@@ -441,7 +441,7 @@ class GroupValidator(Validator):
             self.indent = indent
         for symbol in self.symbols:
             values = []
-            for entry in self.symbols[symbol]:
+            for entry in [e for e in self.symbols[symbol] if e != 'doc']:
                 values.append(self.symbols[symbol][entry])
             if not values:
                 continue


### PR DESCRIPTION
* Removes the 'doc' element when creating symbol tables.
* Renames the `get_classes` function to `get_base_classes` for improved clarity