### PR TITLE
Update the license modifier to use the SPDX identifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ license = {file = "COPYING"}
 authors = [{name = "Raymond Osborn", email = "rayosborn@mac.com"}]
 classifiers = [
   "Development Status :: 4 - Beta",
-  "Modified BSD License",
+  "BSD-3-Clause",
   "Intended Audience :: Developers",
   "Intended Audience :: Science/Research",
   "Topic :: Scientific/Engineering",


### PR DESCRIPTION
The PyPI server is now stricter in ensuring SPDX-compliant license modifiers, so the "Modified BSD License" is now "BSD-3-Clause"