### PR TITLE
Correct typo in the license modifier.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ license = {file = "COPYING"}
 authors = [{name = "Raymond Osborn", email = "rayosborn@mac.com"}]
 classifiers = [
   "Development Status :: 4 - Beta",
-  "BSD-3-Clause",
+  "License :: OSI Approved :: BSD License",
   "Intended Audience :: Developers",
   "Intended Audience :: Science/Research",
   "Topic :: Scientific/Engineering",


### PR DESCRIPTION
Fixes an incorrectly formed license modifier caused by misunderstanding online advice. 