### PR TITLE
Generalize default attributes

### DIFF
--- a/src/nexusformat/definitions/base_classes/NXgoniometer.nxdl.xml
+++ b/src/nexusformat/definitions/base_classes/NXgoniometer.nxdl.xml
@@ -3,7 +3,7 @@
 <!--
 # NeXus - Neutron and X-ray Common Data Format
 # 
-# Copyright (C) 2008-2024 NeXus International Advisory Committee (NIAC)
+# Copyright (C) 2008-2025 NeXus International Advisory Committee (NIAC)
 # 
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -29,14 +29,46 @@
 	>
 
 	<doc>
-		Angles set by a goniometer. 
+		Goniometer rotation angles and sample translations used during a
+		measurement. The goniometers used at neutron and x-ray
+		facilities are typically four-circle or six-circle goniometers,
+		or variants of either one. There is no universally recognized
+		naming convention for angles and translations, so the group
+		should contain a :ref:`NXcite` group, which describes how the
+		angles are defined.
 	</doc>
-	<field name="chi" type="NX_FLOAT" units="NX_ANGLE" />
-	<field name="omega" type="NX_FLOAT" units="NX_ANGLE" />
-	<field name="phi" type="NX_FLOAT" units="NX_ANGLE" />
-	<field name="theta" type="NX_FLOAT" units="NX_ANGLE" />
-	<field name="xs" type="NX_FLOAT" units="NX_LENGTH" />
-	<field name="ys" type="NX_FLOAT" units="NX_LENGTH" />
-	<field name="zs" type="NX_FLOAT" units="NX_LENGTH" />
-</definition>
 
+    <group name="convention" type="NXcite">
+        <doc>
+            A reference to a publication or online documentation that
+            describe the convention used in this group to define the
+            names of angles and sample translations.
+        </doc>
+    </group>
+    <group type="NXcoordinate_system">
+        <doc>
+            The coordinate system used by the translation fields. This
+            group should be present if these fields do not use the
+            default NeXus Coordinate System.
+        </doc>
+    </group>
+    <field name="goniometer">
+        <doc>
+            The common name for the type of goniometer used in these
+            measurements.
+        </doc>
+    </field>
+	<field name="ROTATION_ANGLE" type="NX_FLOAT" units="NX_ANGLE" nameType="any">
+        <doc>
+            One of the goniometer rotation angles defined by the
+            specified convention.
+        </doc>
+    </field>
+    <field name="SAMPLE_TRANSLATION" type="NX_FLOAT" units="NX_LENGTH" nameType="any">
+        <doc>
+            The translation of the sample from the centre of rotation of the
+            goniometer angles along one of the coordinate axes.
+        </doc>
+    </field>
+
+</definition>

--- a/src/nexusformat/definitions/base_classes/NXinstrument.nxdl.xml
+++ b/src/nexusformat/definitions/base_classes/NXinstrument.nxdl.xml
@@ -3,7 +3,7 @@
 <!--
 # NeXus - Neutron and X-ray Common Data Format
 # 
-# Copyright (C) 2008-2024 NeXus International Advisory Committee (NIAC)
+# Copyright (C) 2008-2025 NeXus International Advisory Committee (NIAC)
 # 
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -60,6 +60,7 @@
     <group type="NXfermi_chopper" />
     <group type="NXfilter" />
     <group type="NXflipper" />
+    <group type="NXgoniometer" />
     <group type="NXguide" />
     <group type="NXhistory"/>
     <group type="NXinsertion_device" />

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -4686,8 +4686,6 @@ class NXgroup(NXobject):
         memo[id(self)] = dpcpy
         dpcpy._changed = True
         for k, v in obj.items():
-            if isinstance(v, NXlink):
-                v = v.nxlink
             dpcpy.entries[k] = deepcopy(v, memo)
             dpcpy.entries[k]._group = dpcpy
         for k, v in obj.attrs.items():

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -4780,8 +4780,16 @@ class NXgroup(NXobject):
         list of NXfields or NXgroups
             List of fields or groups of the same class.
         """
-        return [self.entries[i] for i in sorted(self.entries, key=natural_sort)
-                if self.entries[i].nxclass == nxclass]
+        if nxclass == 'NXfield':
+            return [self.entries[i] for i in sorted(self.entries, key=natural_sort)
+                    if isinstance(self.entries[i], NXfield)]
+        elif nxclass == 'NXgroup':
+            return [self.entries[i] for i in sorted(self.entries, key=natural_sort)
+                    if isinstance(self.entries[i], NXgroup)]
+        else:
+            return [self.entries[i] for i in
+                    sorted(self.entries, key=natural_sort)
+                    if self.entries[i].nxclass == nxclass]
 
     def move(self, item, group, name=None):
         """Move an item in the group to another group within the same tree.


### PR DESCRIPTION
* Allows the default data group to be within non-NXentry groups.
* Provides a method of listing all fields and groups within a group using the NXfield and NXgroup attributes, respectively.
* Adds the NXgoniometer base class in anticipation of eventual approval by NIAC. This is needed for the NXRefine package.