### PR TITLE
Fix target updates

### DIFF
--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -1169,7 +1169,8 @@ class NXFile:
                 else:
                     if 'target' not in self[target].attrs:
                         self[target].attrs['target'] = target
-                        self._root[target].attrs['target'] = target
+                        if self._root:
+                            self._root[target].attrs['target'] = target
                     self[path] = self[target]
 
     def readpath(self, path):

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -5907,6 +5907,7 @@ class NXlink(NXobject):
 
     @property
     def nxtarget(self):
+        """Path to the target of the link."""
         return self._target
 
     @nxtarget.setter
@@ -5932,11 +5933,17 @@ class NXlink(NXobject):
         else:
             raise NeXusError("Invalid link target")
         if _target != self._target or _filename != self._filename:
+            original_target = self.nxroot[self._target]
             self._target = _target
             self._filename = _filename
             self._file = None
             self._link = None
             self.update()
+            if not self.is_external():
+                self.nxroot[self._target].update()
+                if original_target.rc == 1:
+                    del original_target.attrs['target']
+                    original_target.update()
 
     @property
     def nxlink(self):

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -1161,17 +1161,17 @@ class NXFile:
         for path, target, soft in links:
             if self._getlink(path)[0] is not None:
                 del self[path]
-            if (path != target and path not in self['/']
-                    and target in self['/']):
+            target_path = str(PurePath(path).parent.joinpath(target))
+            if (path != target_path and path not in self['/']
+                    and target_path in self['/']):
                 if soft:
                     self[path] = h5.SoftLink(target)
-                    self[target].attrs['target'] = target
                 else:
-                    if 'target' not in self[target].attrs:
-                        self[target].attrs['target'] = target
-                        if self._root:
-                            self._root[target].attrs['target'] = target
-                    self[path] = self[target]
+                    self[path] = self[target_path]
+                if 'target' not in self[target_path].attrs:
+                    self[target_path].attrs['target'] = target_path
+                    if self._root:
+                        self._root[target_path].attrs['target'] = target_path
 
     def readpath(self, path):
         """
@@ -5934,15 +5934,16 @@ class NXlink(NXobject):
         else:
             raise NeXusError("Invalid link target")
         if _target != self._target or _filename != self._filename:
-            original_target = self.nxroot[self._target]
+            target_path = self.nxlink.nxpath
+            original_target = self.nxroot[target_path]
             self._target = _target
             self._filename = _filename
             self._file = None
             self._link = None
             self.update()
             if not self.is_external():
-                self.nxroot[self._target].update()
-                if original_target.rc == 1:
+                self.nxlink.update()
+                if original_target.rc == 1 and not self.is_soft():
                     del original_target.attrs['target']
                     original_target.update()
 
@@ -6016,10 +6017,15 @@ class NXlink(NXobject):
                 f"Cannot read the external link to '{self._filename}'")
 
     def is_external(self):
+        """True if the link points to an external file."""
         if self.nxroot is self and self._filename:
             return True
         else:
             return super().is_external()
+
+    def is_soft(self):
+        """True if the link is a soft link."""
+        return self._soft and not self.is_external()
 
     @property
     def attrs(self):

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -2629,6 +2629,46 @@ class NXobject:
         return self.file_exists() and self.path_exists()
 
 
+    @property
+    def id(self):
+        """
+        Return the HDF5 identifier for the object in the NeXus file.
+
+        This only works for objects that within trees saved to a file.
+        Otherwise, None is returned.
+        """
+        if self.nxfilemode:
+            return self.nxfile[self.nxpath].id
+        else:
+            return None
+
+    @property
+    def addr(self):
+        """
+        Return the HDF5 address for the object in the NeXus file.
+
+        This only works for objects that within trees saved to a file.
+        Otherwise, None is returned.
+        """
+        if self.nxfilemode:
+            return h5.h5o.get_info(self.id).addr
+        else:
+            return None
+
+    @property
+    def rc(self):
+        """
+        Return the reference count for the object in the NeXus file.
+
+        This only works for objects that within trees saved to a file.
+        Otherwise, None is returned.
+        """
+        if self.nxfilemode:
+            return h5.h5o.get_info(self.id).rc
+        else:
+            return None
+
+
 class NXfield(NXobject):
 
     """

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -1169,6 +1169,7 @@ class NXFile:
                 else:
                     if 'target' not in self[target].attrs:
                         self[target].attrs['target'] = target
+                        self._root[target].attrs['target'] = target
                     self[path] = self[target]
 
     def readpath(self, path):

--- a/tests/test_links.py
+++ b/tests/test_links.py
@@ -87,7 +87,7 @@ def test_linkgroup_properties(tmpdir, field1a, save):
     root = NXroot(NXentry())
     root["entry/g1"] = NXgroup()
     root["entry/g1/g2"] = NXgroup(field1a)
-    root["entry/g2_link"] = NXlink("entry/g1/g2")
+    root["entry/g2_link"] = NXlink("/entry/g1/g2")
 
     if save:
         filename = os.path.join(tmpdir, "file1.nxs")
@@ -111,7 +111,7 @@ def test_embedded_links(tmpdir, save, field1a, field2a):
     root["entry/g1"] = NXgroup()
     root["entry/g1/g2"] = NXgroup()
     root["entry/g1/g2/g3"] = NXgroup(field1a)
-    root["entry/g2_link"] = NXlink("entry/g1/g2")
+    root["entry/g2_link"] = NXlink("/entry/g1/g2")
 
     if save:
         filename = os.path.join(tmpdir, "file1.nxs")


### PR DESCRIPTION
* Ensures that the NeXus file is updated whenever a link is updated. 
* Uses the HDF5 reference count to remove target attributes if an object is no longer targeted.
* Stores all targets as absolute paths although links may still be initialized using relative paths. When reading a file, it is impossible to tell which object is the parent when using relative paths. 