### PR TITLE
Fix nxtarget property with external links

### DIFF
--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -6093,8 +6093,8 @@ class NXlink(NXobject):
         else:
             raise NeXusError("Invalid link target")
         if _target != self._target or _filename != self._filename:
-            target_path = self.nxlink.nxpath
-            original_target = self.nxroot[target_path]
+            if not self.is_external():
+                original_target = self.nxroot[self.nxlink.nxpath]
             self._target = _target
             self._filename = _filename
             self._file = None


### PR DESCRIPTION
* Only checks for the original target in internal links when checking reference counts. This is used to remove the 'target' attribute when the object is no longer the target of internal links, but is not needed for external links.