### PR TITLE
Add ruff linting and update CI to match nexpy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,24 +1,31 @@
 name: CI
-on: [push, pull_request]
-jobs:
-  build:
 
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: astral-sh/ruff-action@v3
+
+  test:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
-        os: [ubuntu-latest, macOS-latest, windows-latest]
+        python: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
       - uses: actions/checkout@v6
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install dependencies
-        run: |
-          python -m pip install .
-          python -m pip install pytest
-      - name: Test with pytest
-        run: |
-          pytest
+      - uses: astral-sh/setup-uv@v7
+
+      - name: Run tests
+        run: uv run --python ${{ matrix.python }} pytest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.6
+    hooks:
+      - id: ruff-check
+        args: [--fix]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,8 @@ version_file = "src/nexusformat/_version.py"
 [tool.ruff]
 line-length = 88
 target-version = "py39"
+exclude = ["src/nexusformat/notebooks"]
 
 [tool.ruff.lint]
-select = ["F"]
-ignore = ["F403", "F405"]
+select = ["F", "W", "E"]
+ignore = ["F403", "F405", "E721"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,3 +66,11 @@ version_file = "src/nexusformat/_version.py"
 "nexusformat.definitions.contributed_definitions" = ["*.nxdl.xml"]
 "nexusformat.examples" = ["*.nxs", "*.h5"]
 "nexusformat.notebooks" = ["*.pnyb"]
+
+[tool.ruff]
+line-length = 88
+target-version = "py39"
+
+[tool.ruff.lint]
+select = ["F"]
+ignore = ["F403", "F405"]

--- a/src/nexusformat/__init__.py
+++ b/src/nexusformat/__init__.py
@@ -6,4 +6,4 @@
 # The full license is in the file COPYING, distributed with this software.
 # -----------------------------------------------------------------------------
 
-from ._version import version as __version__
+from ._version import __version__ as __version__

--- a/src/nexusformat/nexus/__init__.py
+++ b/src/nexusformat/nexus/__init__.py
@@ -41,7 +41,7 @@ Some files can even be plotted automatically::
 For a complete description of the features available in this tree view
 of the NeXus data file, see `nx.tree`.
 """
-from .completer import nxcompleter
-from .lock import NXLock, NXLockException
+from .completer import nxcompleter as nxcompleter
+from .lock import NXLock as NXLock, NXLockException as NXLockException
 from .tree import *
-import hdf5plugin
+import hdf5plugin  # noqa: F401 (imported for side effects: HDF5 compression filters)

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -226,7 +226,7 @@ from .utils import get_base_classes, remove_deprecations
 warnings.simplefilter('ignore', category=FutureWarning)
 
 # Default configuration parameters.
-NX_CONFIG = {'compression': 'gzip', 'definitions': None, 'encoding': 'utf-8', 
+NX_CONFIG = {'compression': 'gzip', 'definitions': None, 'encoding': 'utf-8',
              'lock': 0, 'lockdirectory': None, 'lockexpiry': 8 * 3600,
              'maxsize': 10000, 'memory': 2000, 'recursive': False}
 # These are overwritten below by environment variables if defined.
@@ -3686,7 +3686,7 @@ class NXfield(NXobject):
         Returns
         -------
         NXfield
-            The average of the field.        
+            The average of the field.
         """
         return NXfield(np.average(self.nxdata, **kwargs),
                        name=self.nxname, attrs=self.safe_attrs)
@@ -3729,7 +3729,7 @@ class NXfield(NXobject):
     def moment(self, order=1, **kwargs):
         """
         Return the moments about the mean of the field.
-        
+
         Other parameters are passed to `scipy.stats.moment`
 
         Parameters
@@ -4021,7 +4021,7 @@ class NXfield(NXobject):
 
     @property
     def nxunits(self):
-        """Units of the field."""        
+        """Units of the field."""
         if 'units' in self.attrs:
             return self.attrs['units']
         else:
@@ -5138,7 +5138,7 @@ class NXgroup(NXobject):
     def get(self, name, default=None):
         """
         Retrieve the group entry.
-        
+
         This returns the default value if the entry doesn't exist.
         """
         try:
@@ -5689,7 +5689,7 @@ class NXgroup(NXobject):
     def validate(self, level='warning', application=None, definitions=None):
         """
         Validate the group against a NeXus application definition.
-        
+
         Note that this can only be used on NXroot and NXentry groups.
 
         Parameters
@@ -6081,7 +6081,7 @@ class NXlink(NXobject):
     @nxtarget.setter
     def nxtarget(self, value):
         if self.nxroot.nxfilemode != 'rw':
-            raise NeXusError("NeXus file opened as readonly") 
+            raise NeXusError("NeXus file opened as readonly")
         elif isinstance(value, NXlink):
             raise NeXusError("Cannot link to another NXlink object")
         elif is_text(value):
@@ -7926,7 +7926,7 @@ class NXdata(NXgroup):
     def nxcoordinates(self):
         """
         List of NXfields defined as signal coordinates.
-        
+
         Note that the use of the coordinates attribute is under
         discussion and has not been formally approved by the NeXus
         standard. However, the attribute can be added to NeXus files
@@ -8374,7 +8374,7 @@ nxsetlockdirectory = setlockdirectory
 def getmaxsize():
     """
     Return the default maximum array size in memory.
-    
+
     If the array size is larger than this value, it will be stored
     in core memory instead.
 

--- a/src/nexusformat/nexus/utils.py
+++ b/src/nexusformat/nexus/utils.py
@@ -54,7 +54,7 @@ def get_logger():
         logger.addHandler(gui_handler)
     else:
         stream_handler = logging.StreamHandler(stream=sys.stdout)
-        stream_handler.setFormatter(NXFormatter('%(message)s'))    
+        stream_handler.setFormatter(NXFormatter('%(message)s'))
         logger.addHandler(stream_handler)
     logger.total = {'warning': 0, 'error': 0}
     return logger
@@ -141,7 +141,7 @@ def is_valid_int(dtype):
     bool
         True if the data type is a valid integer type, False otherwise.
     """
-    return np.issubdtype(dtype, np.integer) 
+    return np.issubdtype(dtype, np.integer)
 
 
 def is_valid_float(dtype):
@@ -176,7 +176,7 @@ def is_valid_bool(dtype):
     bool
         True if the data type is a valid boolean type, False otherwise.
     """
-    return np.issubdtype(dtype, np.bool_) or is_valid_int(dtype) 
+    return np.issubdtype(dtype, np.bool_) or is_valid_int(dtype)
 
 
 def is_valid_char(dtype):
@@ -231,7 +231,7 @@ def is_valid_complex(dtype):
     bool
         True if the data type is a valid complex type, False otherwise.
     """
-    return np.issubdtype(dtype, np.complex) 
+    return np.issubdtype(dtype, np.complex)
 
 
 def is_valid_number(dtype):
@@ -248,7 +248,7 @@ def is_valid_number(dtype):
     bool
         True if the data type is a valid number type, False otherwise.
     """
-    return np.issubdtype(dtype, np.number) 
+    return np.issubdtype(dtype, np.number)
 
 
 def is_valid_posint(dtype):
@@ -269,7 +269,7 @@ def is_valid_posint(dtype):
     if np.issubdtype(dtype, np.integer):
          info = np.iinfo(dtype)
          return info.max > 0
-    return False 
+    return False
 
 
 def is_valid_uint(dtype):
@@ -287,7 +287,7 @@ def is_valid_uint(dtype):
         True if the data type is a valid unsigned integer type, False
         otherwise.
     """
-    return np.issubdtype(dtype, np.unsignedinteger) 
+    return np.issubdtype(dtype, np.unsignedinteger)
 
 
 def all_dtypes():
@@ -331,7 +331,7 @@ def map_dtype(nexus_type):
                                   "uint16", "uint8"],
                     "NX_PCOMPLEX": ["complex128", "complex64"],
                     "NX_POSINT": ["uint64", "uint32", "uint16", "uint8"],
-                    "NX_QUATERNION": ["complex128", "complex64"], 
+                    "NX_QUATERNION": ["complex128", "complex64"],
                     "NX_UINT": ["uint8", "uint16", "uint32", "uint64"],
                     "NX_CHAR_OR_NUMBER": ["str", "bytes", "float64", "float32",
                                           "int64", "int32", "int16", "int8",
@@ -348,7 +348,7 @@ def strip_namespace(element):
     ----------
     element : xml.etree.ElementTree.Element
         The XML element to strip namespace from.
-    """    
+    """
     if '}' in element.tag:
         element.tag = element.tag.split('}', 1)[1]
     for child in element:
@@ -425,7 +425,7 @@ def xml_to_dict(element):
                     result[child.tag]['dim'].update(
                         {int(item.attrib['index']): item.attrib['value']})
         else:
-            child_dict = convert_xml_dict(xml_to_dict(child))       
+            child_dict = convert_xml_dict(xml_to_dict(child))
             if child.tag in result:
                 result[child.tag].update(child_dict)
             else:
@@ -501,10 +501,10 @@ def match_strings(pattern_string, target_string):
     """
     start_pattern = r'^([A-Z]+)([a-z_]+)$'
     end_pattern = r'^([a-z_]+)([A-Z]+)$'
-    
+
     start_match = re.match(start_pattern, pattern_string)
     end_match = re.match(end_pattern, pattern_string)
-    
+
     if start_match:
         lowercase_part = start_match.group(2)
         target_pattern = f'^[a-z_]+{re.escape(lowercase_part)}$'
@@ -515,7 +515,7 @@ def match_strings(pattern_string, target_string):
         target_pattern = f'^{re.escape(lowercase_part)}[a-z_]+$'
         if re.match(target_pattern, target_string):
             return True
-    
+
     return False
 
 
@@ -645,7 +645,7 @@ def check_nametype(item):
 def check_dimension_sizes(dimensions):
     """
     Check if a list of values are all within one of each other.
-    
+
     This handles the case where axis bin boundaries are stored.
 
     Parameters
@@ -682,7 +682,7 @@ class NXFormatter(logging.Formatter):
         'ERROR': Fore.red + Style.BOLD,
         'CRITICAL': Style.reset
     }
-    
+
     def format(self, record):
         """Format the specified record as text."""
         log_color = self.COLORS.get(record.levelname, Style.reset)

--- a/src/nexusformat/nexus/validate.py
+++ b/src/nexusformat/nexus/validate.py
@@ -54,7 +54,7 @@ def get_validator(nxclass, definitions=None):
 
 
 class Validator():
-    
+
     def __init__(self, definitions=None):
         """
         Initializes a new Validator instance.
@@ -333,7 +333,7 @@ class GroupValidator(Validator):
                     self.log(f'The NXDL file uses an invalid name type '
                              f'"{nameType}"', level='error')
         self.valid_fields = valid_fields
-        self.partial_fields = partial_fields    
+        self.partial_fields = partial_fields
 
     def get_valid_groups(self):
         """
@@ -368,7 +368,7 @@ class GroupValidator(Validator):
                              f'"{nameType}"', level='error')
         self.valid_groups = valid_groups
         self.partial_groups = partial_groups
-    
+
     def get_valid_attributes(self):
         """
         Retrieves valid group attributes from the NXDL file.
@@ -508,8 +508,8 @@ class GroupValidator(Validator):
                     self.log(f'{entry}: {self.symbols[symbol][entry]}',
                              level='warning')
                 self.indent -= 1
-            
-    def validate(self, group, parent=None, indent=0, level=None): 
+
+    def validate(self, group, parent=None, indent=0, level=None):
         """
         Validates a given group against the NeXus standard.
 
@@ -613,7 +613,7 @@ class GroupValidator(Validator):
             self.check_data(group)
 
         self.reset_symbols()
-        for entry in group.entries: 
+        for entry in group.entries:
             item = group.entries[entry]
             if isinstance(item, NXfield):
                 if entry in self.valid_fields:
@@ -633,7 +633,7 @@ class GroupValidator(Validator):
         self.check_symbols()
         self.output_log()
         self.indent -= 1
-                
+
 
 class FieldValidator(Validator):
 
@@ -654,7 +654,7 @@ class FieldValidator(Validator):
         dtype : str
             The NeXus data type to validate against.
         """
-        if dtype == 'NX_DATE_TIME': 
+        if dtype == 'NX_DATE_TIME':
             if is_valid_iso8601(field.nxvalue):
                 self.log('The field value is a valid NX_DATE_TIME')
             else:
@@ -676,63 +676,63 @@ class FieldValidator(Validator):
                 self.log('The field value is a valid NX_BOOLEAN')
             else:
                 self.log('The field value is not a valid NX_BOOLEAN',
-                         level='warning')         
+                         level='warning')
         elif dtype == 'NX_CHAR':
             if is_valid_char(field.dtype):
                 self.log('The field value is a valid NX_CHAR')
             else:
                 self.log('The field value is not a valid NX_CHAR',
-                         level='warning')                  
+                         level='warning')
         elif dtype == 'NX_CHAR_OR_NUMBER':
             if is_valid_char_or_number(field.dtype):
                 self.log('TThe field value is a valid NX_CHAR_OR_NUMBER')
             else:
                 self.log('The field value is not a valid NX_CHAR_OR_NUMBER',
-                         level='warning')                
+                         level='warning')
         elif dtype == 'NX_COMPLEX':
             if is_valid_complex(field.dtype):
                 self.log('The field value is a valid NX_COMPLEX value')
             else:
                 self.log('The field value is not a valid NX_COMPLEX value',
-                         level='warning') 
+                         level='warning')
         elif dtype == 'NX_PCOMPLEX':
             if is_valid_complex(field.dtype):
                 self.log('The field value is a valid NX_PCOMPLEX value')
             else:
                 self.log('The field value is not a valid NX_PCOMPLEX value',
-                         level='warning') 
+                         level='warning')
         elif dtype == 'NX_NUMBER':
             if is_valid_number(field.dtype):
                 self.log('The field value is a valid NX_NUMBER')
             else:
                 self.log('The field value is not a valid NX_NUMBER',
-                         level='warning')       
+                         level='warning')
         elif dtype == 'NX_POSINT':
             if is_valid_posint(field.dtype):
                 self.log('The field value is a valid NX_POSINT')
             else:
                 self.log('The field value is not a valid NX_POSINT',
-                         level='warning')    
+                         level='warning')
         elif dtype == 'NX_UINT':
             if is_valid_uint(field.dtype):
                 self.log('The field value is a valid NX_UINT')
             else:
                 self.log('The field value is not a valid NX_UINT',
-                         level='warning')        
+                         level='warning')
 
     def check_dimensions(self, field, dimensions):
         """
         Checks the field dimensions against the specified dimensions.
-        
+
         Note that inconsistencies with the NeXus definition are not
         listed as warnings, because this aspect of the NeXus standard
         needs to be revised.
-        
+
         Parameters
         ----------
-        field : 
+        field :
             The field to check dimensions for.
-        dimensions : 
+        dimensions :
             The base class attribute containing the dimensions to check
             against.
         """
@@ -770,16 +770,16 @@ class FieldValidator(Validator):
                     else:
                         self.log(f'The field has size {field.shape}, '
                                  f'should be {s}')
-    
+
     def check_enumeration(self, field, enumerations):
         """
         Checks if a field's value is a valid member of an enumerated list.
 
         Parameters
         ----------
-        field : 
+        field :
             The field to check the value for.
-        enumerations : 
+        enumerations :
             The list of valid enumerated values.
         """
         if field.nxvalue in enumerations:
@@ -788,7 +788,7 @@ class FieldValidator(Validator):
         else:
             self.log(
                 'The field value is not a member of the enumerated list',
-                level='error') 
+                level='error')
 
     def check_attributes(self, field, attributes=None, units=None):
         """
@@ -796,7 +796,7 @@ class FieldValidator(Validator):
 
         Parameters
         ----------
-        field : 
+        field :
             The field to check attributes for.
         units : optional
             The units of the field. If provided, checks if the units are
@@ -832,7 +832,7 @@ class FieldValidator(Validator):
                                 f'"@{field_attribute}" matches the defined '
                                 f'attribute "{attr}"')
                             checked_attributes.append(attr)
-                            checked_attributes.append(field_attribute)  
+                            checked_attributes.append(field_attribute)
                 if attr not in checked_attributes:
                     self.log(
                         f'The defined attribute "@{attr}" is not present')
@@ -894,7 +894,7 @@ class FieldValidator(Validator):
                 self.log(f'This field is now deprecated. {tag["@deprecated"]}',
                          level='warning')
             if field.exists():
-                if '@type' in tag:  
+                if '@type' in tag:
                     self.check_type(field, tag['@type'])
                 if 'dimensions' in tag:
                     self.check_dimensions(field, tag['dimensions'])
@@ -936,7 +936,7 @@ class FileValidator(Validator):
     def validate(self, path=None):
         """
         Validates a NeXus file by walking through its tree structure.
-        
+
         Each group is validated by its corresponding GroupValidator.
 
         Parameters
@@ -1018,7 +1018,7 @@ class ApplicationValidator(Validator):
         super().__init__(definitions=definitions)
         self.symbols = {}
         self.xml_dict = self.load_application(application)
-        
+
     def load_application(self, application):
         """
         Loads an application definition from an XML file.
@@ -1039,7 +1039,7 @@ class ApplicationValidator(Validator):
         elif self.applications is not None:
             app_path = self.applications / (f'{application}.nxdl.xml')
             if not app_path.exists() and self.contributions is not None:
-                app_path = self.contributions / (f'{application}.nxdl.xml') 
+                app_path = self.contributions / (f'{application}.nxdl.xml')
         elif self.contributions is not None:
             app_path = self.contributions / (f'{application}.nxdl.xml')
         else:
@@ -1141,7 +1141,7 @@ class ApplicationValidator(Validator):
                         self.output_log()
         group_validator.check_symbols(indent=self.indent)
         self.output_log()
-    
+
     def validate(self, entry, level=None):
         """
         Validates a NeXus entry against an XML definition.
@@ -1291,7 +1291,7 @@ def log(message, level='info', indent=0):
         logger.critical(f'{4*indent*" "}{message}')
 
 
-def log_header(validator, filename=None, path=None, application=None):  
+def log_header(validator, filename=None, path=None, application=None):
     log("\n", level='all')
     if filename is not None:
         log(f"Filename: {filename}", level='all')
@@ -1324,6 +1324,6 @@ def log_summary():
     else:
         log(f'\nTotal number of errors: {logger.total["error"]}\n',
             level='all')
-    
+
     return (logger.total['warning'], logger.total['error'])
 

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1,5 +1,3 @@
-import sys
-
 import h5py as h5
 import numpy as np
 import pytest

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -174,5 +174,5 @@ def test_numpy_conversion(arr, request):
     field = NXfield(arr)
 
     assert np.array_equal(field, arr)
-    assert np.array_equal(np.array(field, dtype=np.float32), 
+    assert np.array_equal(np.array(field, dtype=np.float32),
                           arr.astype(np.float32))

--- a/tests/test_locks.py
+++ b/tests/test_locks.py
@@ -96,11 +96,10 @@ def test_lock_defaults(tmpdir, field4):
     root.save(filename, "w")
 
     with root.nxfile as f:
-
-        assert isinstance(root.nxfile.lock, NXLock)
-        assert root.nxfile.lock.timeout == 20
-        assert root.nxfile.locked
-        assert root.nxfile.is_locked()
+        assert isinstance(f.lock, NXLock)
+        assert f.lock.timeout == 20
+        assert f.locked
+        assert f.is_locked()
 
     assert not root.nxfile.locked
     assert not root.nxfile.is_locked()
@@ -110,9 +109,8 @@ def test_lock_defaults(tmpdir, field4):
     root.save(filename, "w")
 
     with root.nxfile as f:
-
-        assert not root.nxfile.locked
-        assert not root.nxfile.is_locked()
+        assert not f.locked
+        assert not f.is_locked()
 
 
 def test_nested_locks(tmpdir, field4):


### PR DESCRIPTION
## Summary
- Migrate CI from pip/setup-python to uv/setup-uv, matching nexpy's workflow
- Add minimal ruff linting config (`F`, `W`, `E` rules) with fixes
- Add ruff as a CI check and pre-commit hook

## Ruff config summary
Adds baseline Pyflakes (`F`) and pycodestyle warnings & errors (`W` & `E`).
We intentionally ignore 3 rules:
- `F403`, `F405`: star imports used in `__init__.py` for the public API
- `E721`: type comparisons using `==` are needed for numpy dtype checks

`F401` suppressed for `hdf5plugin` import
Notebooks are excluded

## Pre-commit
A `.pre-commit-config.yaml` is included so contributors can optionally run `pre-commit install` (or `prek install`) for local linting.