### PR TITLE
Allow-linkfield-assignments

### DIFF
--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -4943,10 +4943,11 @@ class NXgroup(NXobject):
             elif isinstance(value, NXlink):
                 raise NeXusError(
                     "Cannot assign an NXlink to an existing group entry")
-            elif isinstance(group.entries[key], NXlink):
-                raise NeXusError("Cannot assign values to an NXlink")
             elif group.entries[key].is_linked():
                 raise NeXusError("Cannot modify an item in linked group")
+            elif isinstance(group.entries[key], NXlink):
+                group.entries[key].nxlink = value
+                return
             group.entries[key].nxdata = value
             if isinstance(value, NXfield):
                 group.entries[key]._setattrs(value.attrs)

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -5975,6 +5975,16 @@ class NXlink(NXobject):
             object.__setattr__(self, name, value)
         elif self.is_external():
             raise NeXusError("Cannot modify an external link")
+        elif name == 'nxlink':
+            obj = self.nxlink
+            if isinstance(obj, NXfield):
+                if obj._group is not None:
+                    obj._group[obj.nxname] = value
+                else:
+                    obj.nxdata = value
+                    obj.update()
+            else:
+                raise NeXusError("Cannot modify a linked group")
         else:
             try:
                 self.nxlink.setattr(name, value)


### PR DESCRIPTION
* Allows values to be assigned to a NXlink using the nxlink attribute.
* Allows the value of a linked object to be updated with a dictionary assignment to the NXlink. 