### PR TITLE
Skip self-copy when reading uncopied lazy-loaded field

### DIFF
--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -3286,7 +3286,16 @@ class NXfield(NXobject):
                 return f.readvalue(_path, idx=idx)
             else:
                 if self.nxfilemode == 'rw':
-                    f.copy(_path, self.nxpath)
+                    # Skip the copy if the field already lives at the
+                    # destination path. This happens when a file-backed
+                    # field is deep-copied into a new container that
+                    # ends up at the same on-disk location (e.g. the
+                    # PlotDialog wraps a field in an in-memory NXdata
+                    # whose nxpath collides with the source). HDF5
+                    # otherwise raises 'destination object already
+                    # exists' here.
+                    if _path != self.nxpath:
+                        f.copy(_path, self.nxpath)
                 else:
                     self._create_memfile()
                     f.copy(_path, self._memfile, name='data')

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -1,8 +1,9 @@
 import os
 
+import numpy as np
 import pytest
-from nexusformat.nexus.tree import (NXdata, NXentry, NXFile, NXroot, nxload,
-                                    nxopen)
+from nexusformat.nexus.tree import (NXdata, NXentry, NXfield, NXFile, NXroot,
+                                    nxload, nxopen)
 
 
 def test_file_creation(tmpdir):
@@ -80,3 +81,44 @@ def test_file_context_manager(tmpdir, field1, field2):
     assert "entry/data/f2" in w2
     assert "signal" in w2["entry/data"].attrs
     assert "axes" in w2["entry/data"].attrs
+
+
+def test_read_lazy_field_after_same_path_rewrap(tmpdir):
+    """A file-backed NXfield that has been deep-copied into a new
+    in-memory container at the same on-disk path used to raise
+    ``RuntimeError: destination object already exists`` when read,
+    because ``_get_uncopied_data`` asked HDF5 to copy the field onto
+    itself. This is the scenario hit by the nexpy PlotDialog when a
+    field inside an NXdata is selected as the signal: the dialog
+    wraps it in a fresh NXdata with the same name and reparents to
+    the original grandparent, so the wrapped field's nxpath collides
+    with the source. The field must be large enough to stay
+    lazy-loaded (``_value is None``) so the deepcopy preserves the
+    ``_uncopied_data`` reference.
+    """
+    filename = os.path.join(tmpdir, "file.nxs")
+    shape = (2000, 2000)  # big enough to stay lazy-loaded
+    root = NXroot(NXentry(NXdata(
+        NXfield(np.zeros(shape, dtype=np.int64), name="signal"),
+        name="data")))
+    root["entry/data/signal_mask"] = NXfield(np.zeros(shape, dtype=bool))
+    root["entry/data/signal"].attrs["mask"] = "signal_mask"
+    root.save(filename, mode="w")
+    del root
+
+    root = nxload(filename, "rw")
+    src = root["entry/data"]
+    # Mimic PlotDialog: wrap the mask in a new NXdata named after the
+    # original group, reparented to the entry. The wrapped field
+    # ends up at /entry/data/signal_mask -- the same path as the
+    # source.
+    wrapper = NXdata(src["signal_mask"], name=src.nxname)
+    wrapper.nxgroup = src.nxgroup
+    field = wrapper.nxsignal
+    assert field._uncopied_data is not None
+    assert field._uncopied_data[1] == field.nxpath
+
+    arr = field[()]
+    assert arr.shape == shape
+    assert arr.dtype == bool
+    assert field._uncopied_data is None

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -83,21 +83,10 @@ def test_file_context_manager(tmpdir, field1, field2):
     assert "axes" in w2["entry/data"].attrs
 
 
-def test_read_lazy_field_after_same_path_rewrap(tmpdir):
-    """A file-backed NXfield that has been deep-copied into a new
-    in-memory container at the same on-disk path used to raise
-    ``RuntimeError: destination object already exists`` when read,
-    because ``_get_uncopied_data`` asked HDF5 to copy the field onto
-    itself. This is the scenario hit by the nexpy PlotDialog when a
-    field inside an NXdata is selected as the signal: the dialog
-    wraps it in a fresh NXdata with the same name and reparents to
-    the original grandparent, so the wrapped field's nxpath collides
-    with the source. The field must be large enough to stay
-    lazy-loaded (``_value is None``) so the deepcopy preserves the
-    ``_uncopied_data`` reference.
-    """
+def test_read_lazy_field_on_copy(tmpdir):
+
     filename = os.path.join(tmpdir, "file.nxs")
-    shape = (2000, 2000)  # big enough to stay lazy-loaded
+    shape = (2000, 2000)
     root = NXroot(NXentry(NXdata(
         NXfield(np.zeros(shape, dtype=np.int64), name="signal"),
         name="data")))
@@ -108,10 +97,6 @@ def test_read_lazy_field_after_same_path_rewrap(tmpdir):
 
     root = nxload(filename, "rw")
     src = root["entry/data"]
-    # Mimic PlotDialog: wrap the mask in a new NXdata named after the
-    # original group, reparented to the entry. The wrapped field
-    # ends up at /entry/data/signal_mask -- the same path as the
-    # source.
     wrapper = NXdata(src["signal_mask"], name=src.nxname)
     wrapper.nxgroup = src.nxgroup
     field = wrapper.nxsignal


### PR DESCRIPTION
## Summary

When a file-backed `NXfield` is deep-copied (via `NXdata.__init__`, `NXdata.weighted_data`, etc.), `NXfield.__deepcopy__` records `_uncopied_data = (file, source_path)` so the data can be lazily transferred to its new destination at next read. The transfer is done in `NXfield._get_uncopied_data` via `f.copy(source_path, self.nxpath)`.

If the deep-copied field ends up at the **same on-disk path** as the source, h5py refuses the self-copy and raises `RuntimeError: Unable to synchronously copy object (destination object already exists)`.

The case that surfaced this is the nexpy `PlotDialog`: when the user selects a field that already lives inside an `NXdata` (e.g. the `summed_data_mask` companion field), the dialog wraps it in a fresh in-memory `NXdata` named after the original group and reparents to the original grandparent. The deep-copied wrapper's `nxpath` collides with the source on disk, so the read crashes.

The fix is a one-line guard in `_get_uncopied_data`: when source and destination paths agree, the data is already where it needs to be — skip the copy and fall through to the normal `readvalue`. It addresses the symptom directly and also closes the door on any other code path that wraps a file-backed lazy field into a same-on-disk-path container, not just `PlotDialog`.

## Test plan

- [x] New `tests/test_files.py::test_read_lazy_field_after_same_path_rewrap` reproduces the original `RuntimeError` (uses a 2k × 2k mask so the field stays lazy-loaded — small fields skip the bug because their `_value` is already in memory and `__deepcopy__` clears `_uncopied_data`). The test reads cleanly after the fix and asserts the `_uncopied_data` reference is cleared after the read.
- [x] Full suite still passes (`pytest tests/` — 104 tests).
- [ ] Confirmed in nexpy: plotting a mask field (or any field contained in an `NXdata`) via the `PlotDialog` no longer raises `Unable to synchronously copy object`.
