### PR TITLE
Release file locks on close failure and clarify path errors

### DIFF
--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -4886,7 +4886,7 @@ class NXgroup(NXobject):
         try:
             path = PurePath(str(key))
         except TypeError:
-            raise NeXusError("Invalid index")
+            raise NeXusError(f"'{key}' is an invalid index")
         if path.is_absolute():
             node = self.nxroot
             path = path.relative_to('/')
@@ -4896,7 +4896,7 @@ class NXgroup(NXobject):
             try:
                 node = node.entries[name]
             except KeyError:
-                raise NeXusError("Invalid path")
+                raise NeXusError(f"'{path}' is an invalid path")
         return node
 
     def __setitem__(self, key, value):
@@ -5007,7 +5007,7 @@ class NXgroup(NXobject):
                     if name in group:
                         group = group[name]
                     else:
-                        raise NeXusError("Invalid path")
+                        raise NeXusError(f"'{key}' is an invalid path")
             if key not in group:
                 raise NeXusError("'"+key+"' not in "+group.nxpath)
             elif group[key].is_linked():

--- a/src/nexusformat/nexus/tree.py
+++ b/src/nexusformat/nexus/tree.py
@@ -542,9 +542,11 @@ class NXFile:
 
     def __exit__(self, *args):
         """Close the NeXus file and, if necessary, release the lock."""
-        if self._with_count == 1:
-            self.close()
-        self._with_count -= 1
+        try:
+            if self._with_count == 1:
+                self.close()
+        finally:
+            self._with_count -= 1
 
     def __del__(self):
         """Close the file and delete the NXFile instance."""
@@ -721,9 +723,11 @@ class NXFile:
         -----
         The file modification time of the root object is updated.
         """
-        if self.is_open():
-            self._file.close()
-        self.release_lock()
+        try:
+            if self.is_open():
+                self._file.close()
+        finally:
+            self.release_lock()
         try:
             self._root._mtime = self.mtime
         except Exception:


### PR DESCRIPTION
## Summary

Two unrelated fixes bundled together.

### Release file lock even if h5py close raises

`NXFile.close()` previously called `release_lock()` only if the preceding `self._file.close()` did not raise. An h5py flush error during close would therefore strand the `.lock` file on disk, blocking every subsequent `acquire_lock()` on the same file until the 8-hour `expiry` window kicked in. `NXFile.__exit__` had the same shape: a raising `close()` left `_with_count` stuck at 1, so later `with`-blocks on the same NXFile skipped `open()` entirely and never retried the close.

Both are now wrapped in `try/finally` so the lock is always released and the counter always decrements. This was surfaced by an `nxrefine` workflow where a failed `nxlink` task left a stale `.lock` file behind, and subsequent `nxmax` runs on sibling entries blocked indefinitely on `acquire_lock()`.

### Include the offending key in NXgroup path-error messages

`NXgroup.__getitem__` and `__setitem__` raised `NeXusError("Invalid index")` / `NeXusError("Invalid path")` with no indication of which key triggered the failure. The messages now interpolate the offending key or resolved path so the caller can tell at a glance which lookup went wrong.

## Test plan

- [ ] Force an h5py close failure inside a `with nxopen(file, 'rw'):` block and confirm the `.lock` file is removed and `_with_count` returns to 0
- [ ] Re-enter the same NXFile via a new `with` block after a simulated close failure and confirm it acquires the lock cleanly rather than skipping `open()`
- [ ] Trigger `NeXusError` from `NXgroup['/nonexistent/path']` and confirm the message includes the path
- [ ] Existing test suite passes
