### PR TITLE
Record the hostname, not its function object, in lock files

### DIFF
--- a/src/nexusformat/nexus/lock.py
+++ b/src/nexusformat/nexus/lock.py
@@ -83,7 +83,7 @@ class NXLock:
         else:
             self.lock_file = self.filename.with_suffix(suffix)
         self.pid = os.getpid()
-        self.addr = f"{self.pid}@{socket.gethostname}"
+        self.addr = f"{self.pid}@{socket.gethostname()}"
         self.fd = None
 
     def __repr__(self):

--- a/tests/test_locks.py
+++ b/tests/test_locks.py
@@ -1,4 +1,5 @@
 import os
+import socket
 import time
 
 import pytest
@@ -191,7 +192,7 @@ def test_lock_file_removed_on_release(tmpdir):
     assert lock.locked
     assert os.path.exists(lock.lock_file)
     with open(lock.lock_file) as f:
-        assert f.read() == lock.addr
+        assert f.read() == f"{os.getpid()}@{socket.gethostname()}"
 
     lock.release()
 


### PR DESCRIPTION
## Summary

`NXLock` writes `<pid>@<hostname>` into each lock file so that a user who finds a stale lock can tell which process, on which node, left it behind. The call to `socket.gethostname` was missing its parentheses, so the recorded address was always:

```
28727@<built-in function gethostname>
```

This adds the `()`. Lock files now record what they were meant to:

```
28727@CSI364706
```

Only the informational contents of the lock file change — lock acquisition, release, and expiry behaviour are untouched, and the lock file name is unaffected.

The existing test that read the lock file compared its contents against `lock.addr`, which is the same expression that produced them, so it passed against the bug. It now compares against the address it actually expects.
